### PR TITLE
Add PyPI publish workflow and badge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tools
+        run: pip install build
+      - name: Build package
+        run: python -m build
+      - name: Verify package
+        run: |
+          pip install dist/*.whl
+          python -c "import robot_harness; print('Install OK')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **A Visual Testing Harness for AI Coding Agents in Robot Simulation**
 
+[![PyPI](https://img.shields.io/pypi/v/robot-harness)](https://pypi.org/project/robot-harness/)
 [![CI](https://github.com/MiaoDX/RobotHarness/actions/workflows/ci.yml/badge.svg)](https://github.com/MiaoDX/RobotHarness/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
- Add GitHub Actions workflow triggered on tag push (v*) for automated
  PyPI publishing using trusted publisher (OIDC)
- Build job verifies the package installs correctly before publishing
- Add PyPI version badge to README

Closes #3

https://claude.ai/code/session_015JMXZrNRZ4svyTPgL8QPUA