### PR TITLE
feat: add MuJoCo grasp end-to-end example (closes #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,57 @@ jobs:
         run: pip install -e ".[dev]"
       - name: Run tests
         run: pytest
+
+  mujoco-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies (OSMesa for headless rendering)
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
+
+      - name: Install package with MuJoCo backend
+        run: pip install -e ".[mujoco]" Pillow
+
+      - name: Run MuJoCo grasp example
+        env:
+          MUJOCO_GL: osmesa
+        run: python examples/mujoco_grasp.py --report --output-dir ./harness_output
+
+      - name: Upload visual artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mujoco-grasp-output
+          path: |
+            harness_output/report.html
+            harness_output/mujoco_grasp/trial_001/**/*_rgb.png
+            harness_output/mujoco_grasp/trial_001/**/metadata.json
+          retention-days: 30
+
+      - name: Post summary with checkpoint images
+        run: |
+          echo "## MuJoCo Grasp Example Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Checkpoint captures from the scripted grasp sequence:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          for cp in harness_output/mujoco_grasp/trial_001/*/; do
+            name=$(basename "$cp")
+            echo "### ${name}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            # Embed front view as base64 in summary
+            if [ -f "${cp}front_rgb.png" ]; then
+              echo "![${name} front view](data:image/png;base64,$(base64 -w0 "${cp}front_rgb.png"))" >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ -f "${cp}metadata.json" ]; then
+              step=$(python3 -c "import json; print(json.load(open('${cp}metadata.json'))['step'])")
+              sim_time=$(python3 -c "import json; print(f\"{json.load(open('${cp}metadata.json'))['sim_time']:.3f}\")")
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Step: ${step} | Sim time: ${sim_time}s" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+          done
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "Download the full artifact (including HTML report) from the Actions tab." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ pip install robot-harness[dev]
 
 ## Quick Start
 
+### MuJoCo Grasp Example (End-to-End)
+
+Run a complete grasp simulation with zero external dependencies:
+
+```bash
+pip install robot-harness[mujoco] Pillow
+python examples/mujoco_grasp.py --report
+```
+
+This runs a scripted grasp sequence (hover → lower → grip → lift), captures multi-view screenshots at each checkpoint, and generates an HTML report. See [`examples/mujoco_grasp.py`](examples/mujoco_grasp.py) for the full source.
+
 ### Option 1: Gymnasium Wrapper (Zero-Change Integration)
 
 Wrap any Gymnasium-compatible environment with one line:

--- a/examples/mujoco_grasp.py
+++ b/examples/mujoco_grasp.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""MuJoCo Grasp Example — End-to-end demo of Robot-Harness.
+
+A minimal, self-contained example that demonstrates the full harness workflow:
+  1. Load a MuJoCo model (inline XML, no external files needed)
+  2. Run a scripted grasp sequence
+  3. Capture multi-view screenshots at each checkpoint
+  4. Save everything to disk
+
+Run:
+    pip install robot-harness[mujoco] Pillow
+    python examples/mujoco_grasp.py
+
+Output:
+    ./harness_output/mujoco_grasp/trial_001/
+        pre_grasp/   — gripper open, above the cube
+        contact/     — gripper lowered onto the cube
+        lift/        — cube lifted off the table
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from robot_harness.backends.mujoco_meshcat import MuJoCoMeshcatBackend
+from robot_harness.core.harness import Harness
+
+# ---------------------------------------------------------------------------
+# Inline MJCF model: table + cube + 2-finger gripper + 3 cameras
+# ---------------------------------------------------------------------------
+GRASP_MJCF = """\
+<mujoco model="simple_grasp">
+  <option gravity="0 0 -9.81" timestep="0.002"/>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.6 0.8 1.0" rgb2="0.2 0.3 0.5"
+             width="256" height="256"/>
+    <texture name="grid" type="2d" builtin="checker" rgb1="0.9 0.9 0.9" rgb2="0.7 0.7 0.7"
+             width="256" height="256"/>
+    <material name="grid_mat" texture="grid" texrepeat="4 4" reflectance="0.1"/>
+    <material name="table_mat" rgba="0.6 0.4 0.2 1"/>
+    <material name="cube_mat" rgba="0.9 0.2 0.2 1"/>
+    <material name="gripper_mat" rgba="0.3 0.3 0.7 1"/>
+  </asset>
+
+  <worldbody>
+    <!-- Ground -->
+    <geom type="plane" size="1 1 0.01" material="grid_mat"/>
+    <light pos="0 0 2" dir="0 0 -1" diffuse="0.8 0.8 0.8"/>
+    <light pos="0.5 0.5 1.5" dir="-0.3 -0.3 -1" diffuse="0.4 0.4 0.4"/>
+
+    <!-- Cameras -->
+    <camera name="front" pos="0.75 0 0.55" xyaxes="0 1 0 -0.4 0 0.75"/>
+    <camera name="side" pos="0 0.75 0.55" xyaxes="-1 0 0 0 -0.4 0.75"/>
+    <camera name="top" pos="0 0 1.2" xyaxes="1 0 0 0 1 0"/>
+
+    <!-- Table -->
+    <body name="table" pos="0 0 0.2">
+      <geom type="box" size="0.3 0.3 0.02" material="table_mat"/>
+      <geom type="cylinder" size="0.015 0.1" pos=" 0.25  0.25 -0.12"/>
+      <geom type="cylinder" size="0.015 0.1" pos="-0.25  0.25 -0.12"/>
+      <geom type="cylinder" size="0.015 0.1" pos=" 0.25 -0.25 -0.12"/>
+      <geom type="cylinder" size="0.015 0.1" pos="-0.25 -0.25 -0.12"/>
+    </body>
+
+    <!-- Cube (free body, graspable) -->
+    <body name="cube" pos="0 0 0.25">
+      <joint type="free"/>
+      <geom type="box" size="0.025 0.025 0.025" mass="0.02" material="cube_mat"
+            friction="2.0 0.1 0.001" condim="4" solref="0.01 1" solimp="0.95 0.99 0.001"/>
+    </body>
+
+    <!-- Gripper -->
+    <body name="gripper_base" pos="0 0 0.55">
+      <joint name="gripper_z" type="slide" axis="0 0 1" range="-0.35 0.1" damping="50"/>
+      <geom type="cylinder" size="0.02 0.03" material="gripper_mat"/>
+
+      <body name="finger_left" pos="0 0.04 -0.06">
+        <joint name="finger_left" type="slide" axis="0 1 0" range="-0.02 0.015" damping="0.5"/>
+        <geom type="box" size="0.012 0.012 0.04" material="gripper_mat"
+              friction="2.0 0.1 0.001" condim="4"/>
+      </body>
+
+      <body name="finger_right" pos="0 -0.04 -0.06">
+        <joint name="finger_right" type="slide" axis="0 1 0" range="-0.015 0.02" damping="0.5"/>
+        <geom type="box" size="0.012 0.012 0.04" material="gripper_mat"
+              friction="2.0 0.1 0.001" condim="4"/>
+      </body>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <position name="gripper_z_ctrl" joint="gripper_z" kp="200" ctrlrange="-0.35 0.1"/>
+    <position name="finger_left_ctrl" joint="finger_left" kp="100" ctrlrange="-0.02 0.015"/>
+    <position name="finger_right_ctrl" joint="finger_right" kp="100" ctrlrange="-0.015 0.02"/>
+  </actuator>
+</mujoco>
+"""
+
+# ---------------------------------------------------------------------------
+# Grasp action sequence
+# ---------------------------------------------------------------------------
+# Controls: [gripper_z_position, finger_left, finger_right]
+# Positive finger_left = open left, Positive finger_right = open right
+
+
+def make_action_sequence(
+    target_z: float, finger_left: float, finger_right: float, n_steps: int
+) -> list[np.ndarray]:
+    """Create a constant-action sequence for n_steps.
+
+    Controls: [gripper_z, finger_left, finger_right]
+      finger_left  range [-0.03, 0.01]: -0.03 = closed, 0.01 = open
+      finger_right range [-0.01, 0.03]:  0.03 = closed, -0.01 = open
+    """
+    action = np.array([target_z, finger_left, finger_right])
+    return [action for _ in range(n_steps)]
+
+
+def build_grasp_phases() -> dict[str, list[np.ndarray]]:
+    """Build the scripted grasp motion in phases.
+
+    Returns a dict mapping phase_name -> action_sequence.
+    """
+    # Finger positions (asymmetric joint ranges)
+    left_open, left_closed = 0.015, -0.02
+    right_open, right_closed = -0.015, 0.02
+
+    return {
+        # Phase 1: Open gripper, hover above cube
+        "pre_grasp": make_action_sequence(
+            target_z=0.05, finger_left=left_open, finger_right=right_open,
+            n_steps=500,
+        ),
+        # Phase 2: Lower onto cube, fingers still open
+        "contact": make_action_sequence(
+            target_z=-0.24, finger_left=left_open, finger_right=right_open,
+            n_steps=500,
+        ),
+        # Phase 3: Close fingers around cube (stay at contact height)
+        "grasp": make_action_sequence(
+            target_z=-0.24, finger_left=left_closed, finger_right=right_closed,
+            n_steps=800,
+        ),
+        # Phase 4: Lift with fingers closed
+        "lift": make_action_sequence(
+            target_z=-0.10, finger_left=left_closed, finger_right=right_closed,
+            n_steps=800,
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTML report generator
+# ---------------------------------------------------------------------------
+
+
+def generate_html_report(output_dir: Path) -> Path:
+    """Generate a self-contained HTML report showing all checkpoint captures.
+
+    Embeds images as base64 so the HTML file works standalone (no server needed).
+    """
+    import base64
+
+    trial_dir = output_dir / "mujoco_grasp" / "trial_001"
+    if not trial_dir.exists():
+        return output_dir / "report.html"
+
+    checkpoints = sorted(
+        [d for d in trial_dir.iterdir() if d.is_dir()],
+        key=lambda p: p.name,
+    )
+
+    rows_html = []
+    for cp_dir in checkpoints:
+        cp_name = cp_dir.name
+
+        # Read metadata
+        meta_path = cp_dir / "metadata.json"
+        meta = {}
+        if meta_path.exists():
+            with open(meta_path) as f:
+                meta = json.load(f)
+
+        # Collect images
+        images_html = []
+        for img_file in sorted(cp_dir.glob("*_rgb.png")):
+            cam_name = img_file.stem.replace("_rgb", "")
+            with open(img_file, "rb") as f:
+                b64 = base64.b64encode(f.read()).decode()
+            images_html.append(
+                f'<div class="cam">'
+                f'<img src="data:image/png;base64,{b64}" alt="{cam_name}"/>'
+                f"<p>{cam_name}</p></div>"
+            )
+
+        step = meta.get("step", "?")
+        sim_time = meta.get("sim_time", "?")
+        if isinstance(sim_time, float):
+            sim_time = f"{sim_time:.3f}"
+
+        rows_html.append(
+            f'<div class="checkpoint">'
+            f"<h2>{cp_name}</h2>"
+            f"<p>Step: {step} | Sim time: {sim_time}s</p>"
+            f'<div class="views">{"".join(images_html)}</div>'
+            f"</div>"
+        )
+
+    html = f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<title>Robot-Harness MuJoCo Grasp Report</title>
+<style>
+  body {{ font-family: -apple-system, sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px;
+         background: #f5f5f5; }}
+  h1 {{ color: #333; border-bottom: 2px solid #4a90d9; padding-bottom: 10px; }}
+  .checkpoint {{ background: white; border-radius: 8px; padding: 20px; margin: 20px 0;
+                 box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+  .checkpoint h2 {{ color: #4a90d9; margin-top: 0; }}
+  .views {{ display: flex; gap: 16px; flex-wrap: wrap; }}
+  .cam {{ text-align: center; }}
+  .cam img {{ max-width: 320px; border: 1px solid #ddd; border-radius: 4px; }}
+  .cam p {{ margin: 4px 0 0; font-size: 14px; color: #666; }}
+  .footer {{ margin-top: 30px; color: #999; font-size: 12px; }}
+</style>
+</head>
+<body>
+<h1>Robot-Harness: MuJoCo Grasp Example</h1>
+<p>Visual checkpoint captures from the scripted grasp sequence.</p>
+{"".join(rows_html)}
+<div class="footer">
+  Generated by <code>examples/mujoco_grasp.py --report</code>
+</div>
+</body>
+</html>
+"""
+    report_path = output_dir / "report.html"
+    report_path.write_text(html)
+    return report_path
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Robot-Harness MuJoCo Grasp Example")
+    parser.add_argument(
+        "--output-dir",
+        default="./harness_output",
+        help="Output directory (default: ./harness_output)",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Generate an HTML report after the run",
+    )
+    parser.add_argument(
+        "--width", type=int, default=640, help="Render width (default: 640)"
+    )
+    parser.add_argument(
+        "--height", type=int, default=480, help="Render height (default: 480)"
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    cameras = ["front", "side", "top"]
+
+    print("=" * 60)
+    print("  Robot-Harness: MuJoCo Grasp Example")
+    print("=" * 60)
+
+    # 1. Create backend from inline XML
+    print("\n[1/4] Loading MuJoCo model (inline XML) ...")
+    backend = MuJoCoMeshcatBackend(
+        xml_string=GRASP_MJCF,
+        cameras=cameras,
+        render_width=args.width,
+        render_height=args.height,
+    )
+    print("      Model loaded. Actuators: 3 (z-slide, left-finger, right-finger)")
+
+    # 2. Set up harness with checkpoints
+    print("[2/4] Setting up harness with checkpoints ...")
+    harness = Harness(backend, output_dir=str(output_dir), task_name="mujoco_grasp")
+    phases = build_grasp_phases()
+    for phase_name in phases:
+        harness.add_checkpoint(phase_name, cameras=cameras)
+    print(f"      Checkpoints: {harness.list_checkpoints()}")
+
+    # 3. Run the grasp sequence
+    print("[3/4] Running grasp simulation ...")
+    harness.reset()
+
+    for phase_name, actions in phases.items():
+        result = harness.run_to_next_checkpoint(actions)
+        if result is None:
+            print(f"      WARNING: No checkpoint for phase '{phase_name}'")
+            continue
+
+        n_views = len(result.views)
+        trial_dir = output_dir / "mujoco_grasp" / "trial_001" / phase_name
+        print(
+            f"      Checkpoint '{phase_name}': {n_views} views captured"
+            f" | step={result.step} | sim_time={result.sim_time:.3f}s"
+        )
+        print(f"        -> {trial_dir}")
+
+    # 4. Summary
+    print("\n[4/4] Done!")
+    trial_dir = output_dir / "mujoco_grasp" / "trial_001"
+    total_images = len(list(trial_dir.rglob("*_rgb.png"))) if trial_dir.exists() else 0
+    print(f"      {total_images} images saved to: {trial_dir}")
+
+    if args.report:
+        report_path = generate_html_report(output_dir)
+        print(f"      HTML report: {report_path}")
+
+    # Print tree-like summary
+    print("\n  Output structure:")
+    if trial_dir.exists():
+        for cp_dir in sorted(trial_dir.iterdir()):
+            if cp_dir.is_dir():
+                files = sorted(f.name for f in cp_dir.iterdir() if f.is_file())
+                print(f"    {cp_dir.name}/")
+                for fname in files:
+                    print(f"      {fname}")
+
+    print("\n" + "=" * 60)
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/src/robot_harness/backends/mujoco_meshcat.py
+++ b/src/robot_harness/backends/mujoco_meshcat.py
@@ -32,10 +32,11 @@ class MuJoCoMeshcatBackend:
 
     def __init__(
         self,
-        model_path: str | Path,
+        model_path: str | Path | None = None,
         cameras: list[str] | None = None,
         render_width: int = 640,
         render_height: int = 480,
+        xml_string: str | None = None,
     ):
         try:
             import mujoco
@@ -45,13 +46,19 @@ class MuJoCoMeshcatBackend:
                 "Install with: pip install robot-harness[mujoco]"
             )
 
-        self._model_path = Path(model_path)
+        if xml_string is None and model_path is None:
+            raise ValueError("Either model_path or xml_string must be provided.")
+
         self._camera_names = cameras or ["front"]
         self._render_width = render_width
         self._render_height = render_height
 
         # Load MuJoCo model
-        self._model = mujoco.MjModel.from_xml_path(str(self._model_path))
+        if xml_string is not None:
+            self._model = mujoco.MjModel.from_xml_string(xml_string)
+        else:
+            self._model_path = Path(model_path)  # type: ignore[arg-type]
+            self._model = mujoco.MjModel.from_xml_path(str(self._model_path))
         self._data = mujoco.MjData(self._model)
         self._renderer = mujoco.Renderer(
             self._model, height=self._render_height, width=self._render_width


### PR DESCRIPTION
- Add examples/mujoco_grasp.py with inline MJCF model (table + cube +
  2-finger gripper), scripted grasp sequence, multi-view checkpoint
  captures, and optional HTML report generation
- Extend MuJoCoMeshcatBackend to accept xml_string parameter for
  loading models without external files
- Add CI job (mujoco-example) that runs the example headlessly with
  OSMesa, uploads visual artifacts, and posts checkpoint images to
  the GitHub Actions step summary
- Update README Quick Start with MuJoCo example instructions

https://claude.ai/code/session_01T5U94fGksPxpXo1pvedUME