### PR TITLE
feat: add Meshcat interactive 3D scene to HTML report

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install system dependencies (OSMesa for headless rendering)
         run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
 
-      - name: Install package with MuJoCo backend
-        run: pip install -e ".[mujoco]" Pillow
+      - name: Install package with MuJoCo and Meshcat backends
+        run: pip install -e ".[mujoco,meshcat]" Pillow
 
       - name: Run MuJoCo grasp example
         env:
@@ -41,12 +41,13 @@ jobs:
           # Copy the HTML report
           cp harness_output/report.html _site/index.html
 
-          # Copy all checkpoint images (flat structure for easy linking)
+          # Copy all checkpoint images and Meshcat exports (flat structure for easy linking)
           for cp_dir in harness_output/mujoco_grasp/trial_001/*/; do
             cp_name=$(basename "$cp_dir")
             mkdir -p "_site/${cp_name}"
             cp "${cp_dir}"*_rgb.png "_site/${cp_name}/" 2>/dev/null || true
             cp "${cp_dir}"*_depth_viz.png "_site/${cp_name}/" 2>/dev/null || true
+            cp "${cp_dir}"meshcat_scene.html "_site/${cp_name}/" 2>/dev/null || true
             cp "${cp_dir}"metadata.json "_site/${cp_name}/" 2>/dev/null || true
             cp "${cp_dir}"state.json "_site/${cp_name}/" 2>/dev/null || true
           done

--- a/examples/mujoco_grasp.py
+++ b/examples/mujoco_grasp.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import numpy as np
 
 from roboharness.backends.mujoco_meshcat import MuJoCoMeshcatBackend
+from roboharness.backends.visualizer import MeshcatVisualizer
 from roboharness.core.harness import Harness
 
 # ---------------------------------------------------------------------------
@@ -162,7 +163,9 @@ def build_grasp_phases() -> dict[str, list[np.ndarray]]:
 def generate_html_report(output_dir: Path) -> Path:
     """Generate a self-contained HTML report showing all checkpoint captures.
 
-    Embeds images as base64 so the HTML file works standalone (no server needed).
+    Each checkpoint shows static PNG screenshots on the left and an interactive
+    Meshcat 3D viewer (via ``<iframe>``) on the right when available.
+    Images are embedded as base64 so the HTML file works standalone.
     """
     import base64
 
@@ -198,6 +201,20 @@ def generate_html_report(output_dir: Path) -> Path:
                 f"<p>{cam_name}</p></div>"
             )
 
+        # Check for Meshcat interactive HTML export
+        meshcat_file = cp_dir / "meshcat_scene.html"
+        meshcat_html = ""
+        if meshcat_file.exists():
+            # Use a relative path for the iframe src so it works on GitHub Pages
+            meshcat_rel = f"{cp_name}/meshcat_scene.html"
+            meshcat_html = (
+                f'<div class="meshcat-viewer">'
+                f"<h3>Interactive 3D Scene</h3>"
+                f'<iframe src="{meshcat_rel}" loading="lazy"></iframe>'
+                f"<p>Rotate, pan, and zoom to explore the scene.</p>"
+                f"</div>"
+            )
+
         step = meta.get("step", "?")
         sim_time = meta.get("sim_time", "?")
         if isinstance(sim_time, float):
@@ -207,7 +224,10 @@ def generate_html_report(output_dir: Path) -> Path:
             f'<div class="checkpoint">'
             f"<h2>{cp_name}</h2>"
             f"<p>Step: {step} | Sim time: {sim_time}s</p>"
+            f'<div class="checkpoint-content">'
             f'<div class="views">{"".join(images_html)}</div>'
+            f"{meshcat_html}"
+            f"</div>"
             f"</div>"
         )
 
@@ -218,16 +238,22 @@ def generate_html_report(output_dir: Path) -> Path:
 <meta charset="utf-8"/>
 <title>Roboharness MuJoCo Grasp Report</title>
 <style>
-  body {{ font-family: -apple-system, sans-serif; max-width: 1200px; margin: 0 auto; padding: 20px;
+  body {{ font-family: -apple-system, sans-serif; max-width: 1400px; margin: 0 auto; padding: 20px;
          background: #f5f5f5; }}
   h1 {{ color: #333; border-bottom: 2px solid #4a90d9; padding-bottom: 10px; }}
   .checkpoint {{ background: white; border-radius: 8px; padding: 20px; margin: 20px 0;
                  box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
   .checkpoint h2 {{ color: #4a90d9; margin-top: 0; }}
-  .views {{ display: flex; gap: 16px; flex-wrap: wrap; }}
+  .checkpoint-content {{ display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start; }}
+  .views {{ display: flex; gap: 16px; flex-wrap: wrap; flex: 1; min-width: 300px; }}
   .cam {{ text-align: center; }}
   .cam img {{ max-width: 320px; border: 1px solid #ddd; border-radius: 4px; }}
   .cam p {{ margin: 4px 0 0; font-size: 14px; color: #666; }}
+  .meshcat-viewer {{ flex: 0 0 480px; text-align: center; }}
+  .meshcat-viewer h3 {{ color: #4a90d9; margin: 0 0 8px; font-size: 16px; }}
+  .meshcat-viewer iframe {{ width: 480px; height: 400px; border: 1px solid #ddd;
+                            border-radius: 4px; }}
+  .meshcat-viewer p {{ margin: 4px 0 0; font-size: 13px; color: #888; }}
   .footer {{ margin-top: 30px; color: #999; font-size: 12px; }}
 </style>
 </head>
@@ -288,6 +314,20 @@ def main() -> None:
     )
     print("      Model loaded. Actuators: 3 (z-slide, left-finger, right-finger)")
 
+    # Create Meshcat visualizer for interactive 3D export (if meshcat available)
+    meshcat_viz: MeshcatVisualizer | None = None
+    if args.report:
+        try:
+            import mujoco as _mj  # noqa: F401
+
+            meshcat_viz = MeshcatVisualizer(
+                backend._model, backend._data,
+                width=args.width, height=args.height,
+            )
+            print("      Meshcat visualizer ready for 3D scene export.")
+        except ImportError:
+            print("      Meshcat not installed — skipping interactive 3D export.")
+
     # 2. Set up harness with checkpoints
     print("[2/4] Setting up harness with checkpoints ...")
     harness = Harness(backend, output_dir=str(output_dir), task_name="mujoco_grasp")
@@ -313,6 +353,13 @@ def main() -> None:
             f" | step={result.step} | sim_time={result.sim_time:.3f}s"
         )
         print(f"        -> {trial_dir}")
+
+        # Export Meshcat interactive scene for this checkpoint
+        if meshcat_viz is not None:
+            meshcat_viz.sync()
+            scene_path = trial_dir / "meshcat_scene.html"
+            meshcat_viz.export_html(scene_path)
+            print(f"        -> Meshcat 3D: {scene_path}")
 
     # 4. Summary
     print("\n[4/4] Done!")

--- a/src/roboharness/backends/visualizer.py
+++ b/src/roboharness/backends/visualizer.py
@@ -20,7 +20,7 @@ import numpy as np
 from roboharness.core.capture import CameraView
 
 if TYPE_CHECKING:
-    pass
+    from pathlib import Path
 
 
 @runtime_checkable
@@ -260,6 +260,30 @@ class MeshcatVisualizer:
         img[h // 4 : 3 * h // 4, w // 2 - 1 : w // 2 + 1] = [100, 100, 200]
 
         return img
+
+    def export_html(self, path: str | Path) -> Path:
+        """Export the current Meshcat scene as a self-contained HTML file.
+
+        Uses Meshcat's ``static_html()`` to produce a standalone Three.js
+        viewer that can be opened in any browser without a running server.
+
+        Parameters
+        ----------
+        path : str | Path
+            Destination file path (should end with ``.html``).
+
+        Returns
+        -------
+        Path
+            The path to the written HTML file.
+        """
+        from pathlib import Path as _Path
+
+        out = _Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        html = self._vis.static_html()
+        out.write_text(html)
+        return out
 
     @property
     def url(self) -> str:


### PR DESCRIPTION
- Add MeshcatVisualizer.export_html() using meshcat's static_html()
  to produce self-contained Three.js scenes
- Update mujoco_grasp.py --report to export Meshcat HTML at each
  checkpoint alongside PNG screenshots
- Update report layout to show PNGs on the left and an embedded
  interactive 3D iframe on the right per checkpoint
- Install meshcat as optional dependency in pages.yml for GitHub
  Pages builds

Closes #30

https://claude.ai/code/session_01KC7899ej5W6tNGCWoxteDA