### PR TITLE
feat: Isaac Lab integration example and torch tensor compatibility (#4)

### DIFF
--- a/examples/isaac_lab_integration.py
+++ b/examples/isaac_lab_integration.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Isaac Lab Integration — Using RobotHarnessWrapper with Isaac Lab environments.
+
+This example demonstrates how to wrap an Isaac Lab Gymnasium environment
+with Roboharness for checkpoint-based visual capture.
+
+Requirements:
+    - NVIDIA GPU with drivers >= 580.65.06
+    - Isaac Sim + Isaac Lab installed (see https://isaac-sim.github.io/IsaacLab/)
+    - pip install roboharness
+
+Run:
+    # From the Isaac Lab root (with Isaac Sim environment activated):
+    python examples/isaac_lab_integration.py
+
+    # With custom settings:
+    python examples/isaac_lab_integration.py --task Isaac-Reach-Franka-v0 --num-envs 1
+
+Note:
+    Isaac Lab environments return PyTorch tensors (not NumPy arrays) for
+    observations and expect tensors for actions. The RobotHarnessWrapper
+    handles this transparently — it does not modify observations or actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Roboharness + Isaac Lab Integration")
+    parser.add_argument(
+        "--task",
+        default="Isaac-Reach-Franka-v0",
+        help="Isaac Lab task name (default: Isaac-Reach-Franka-v0)",
+    )
+    parser.add_argument(
+        "--num-envs",
+        type=int,
+        default=1,
+        help="Number of parallel environments (default: 1)",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=200,
+        help="Maximum steps per episode (default: 200)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./harness_output",
+        help="Output directory (default: ./harness_output)",
+    )
+    args = parser.parse_args()
+
+    # Isaac Lab requires isaaclab.app to be imported before gymnasium
+    try:
+        from isaaclab.app import AppLauncher
+
+        launcher = AppLauncher(headless=True)
+        launcher.app.start()
+    except ImportError:
+        print("ERROR: Isaac Lab is not installed or not available.")
+        print()
+        print("Isaac Lab requires:")
+        print("  - NVIDIA GPU with drivers >= 580.65.06")
+        print("  - Isaac Sim (Omniverse)")
+        print("  - Isaac Lab (pip install)")
+        print()
+        print("See: https://isaac-sim.github.io/IsaacLab/main/source/setup/installation/index.html")
+        sys.exit(1)
+
+    import gymnasium as gym
+
+    # Isaac Lab registers its envs on import
+    import isaaclab_tasks  # noqa: F401
+
+    from roboharness.wrappers import RobotHarnessWrapper
+
+    print("=" * 60)
+    print("  Roboharness: Isaac Lab Integration")
+    print("=" * 60)
+
+    # 1. Create the Isaac Lab environment via standard Gymnasium API
+    print(f"\n[1/3] Creating environment: {args.task} (num_envs={args.num_envs})")
+    env = gym.make(
+        args.task,
+        num_envs=args.num_envs,
+        render_mode="rgb_array",
+    )
+
+    # 2. Wrap with RobotHarnessWrapper — zero changes to environment code
+    print("[2/3] Wrapping with RobotHarnessWrapper ...")
+    env = RobotHarnessWrapper(
+        env,
+        checkpoints=[
+            {"name": "start", "step": 1},
+            {"name": "quarter", "step": args.max_steps // 4},
+            {"name": "mid", "step": args.max_steps // 2},
+            {"name": "end", "step": args.max_steps},
+        ],
+        cameras=["default"],
+        output_dir=args.output_dir,
+        task_name=args.task.lower().replace("-", "_"),
+    )
+
+    # 3. Run the standard Gymnasium loop
+    print(f"[3/3] Running for up to {args.max_steps} steps ...")
+    obs, info = env.reset()
+    total_reward = 0.0
+
+    for step in range(args.max_steps):
+        action = env.action_space.sample()
+        obs, reward, terminated, truncated, info = env.step(action)
+
+        # reward may be a torch tensor in Isaac Lab
+        if hasattr(reward, "item"):
+            total_reward += reward.item()
+        else:
+            total_reward += float(reward)
+
+        if "checkpoint" in info:
+            cp = info["checkpoint"]
+            print(f"  Checkpoint '{cp['name']}' at step {cp['step']}")
+            print(f"  Captures saved to: {cp['capture_dir']}")
+
+        if terminated or truncated:
+            # Isaac Lab vectorized envs auto-reset, but single-env may terminate
+            if hasattr(terminated, "item"):
+                terminated = terminated.item()
+            if hasattr(truncated, "item"):
+                truncated = truncated.item()
+            if terminated or truncated:
+                print(f"  Episode ended at step {step + 1}, total reward: {total_reward:.2f}")
+                break
+
+    env.close()
+    launcher.app.close()
+
+    print(f"\nDone! Total reward: {total_reward:.2f}")
+    print(f"Check {args.output_dir}/ for captured screenshots and state.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/roboharness/wrappers/gymnasium_wrapper.py
+++ b/src/roboharness/wrappers/gymnasium_wrapper.py
@@ -126,7 +126,7 @@ class RobotHarnessWrapper(Wrapper):  # type: ignore[type-arg]
         # Save state info
         state = {
             "step": self._step_count,
-            "reward": float(reward) if isinstance(reward, (int, float, np.number)) else 0.0,
+            "reward": _to_float(reward),
             "timestamp": time.time(),
             "checkpoint": name,
             "trial": self._trial_count,
@@ -134,6 +134,10 @@ class RobotHarnessWrapper(Wrapper):  # type: ignore[type-arg]
 
         # Include observation summary (avoid dumping huge arrays)
         if isinstance(obs, np.ndarray):
+            state["obs_shape"] = list(obs.shape)
+            state["obs_dtype"] = str(obs.dtype)
+        elif hasattr(obs, "shape") and hasattr(obs, "dtype"):
+            # Torch tensors and similar array-like objects
             state["obs_shape"] = list(obs.shape)
             state["obs_dtype"] = str(obs.dtype)
         elif isinstance(obs, dict):
@@ -162,6 +166,26 @@ class RobotHarnessWrapper(Wrapper):  # type: ignore[type-arg]
             "capture_dir": str(capture_dir),
             "files": saved_files,
         }
+
+
+def _to_float(value: Any) -> float:
+    """Convert a scalar value to float, handling torch tensors and numpy types."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, np.number):
+        return float(value)
+    # Handle torch tensors and similar array-like objects
+    if hasattr(value, "item"):
+        # Multi-element tensors (e.g. vectorized envs): take the mean
+        if hasattr(value, "numel") and value.numel() > 1:
+            return float(value.float().mean().item())
+        if hasattr(value, "size") and isinstance(value.size, int) and value.size > 1:
+            return float(value.mean())
+        return float(value.item())
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def _save_image(arr: np.ndarray, path: Path) -> None:

--- a/tests/test_isaac_lab_compat.py
+++ b/tests/test_isaac_lab_compat.py
@@ -1,0 +1,225 @@
+"""Tests for Isaac Lab compatibility — validates RobotHarnessWrapper with torch tensors.
+
+Isaac Lab environments differ from standard Gymnasium envs in that:
+  - Observations and actions are PyTorch tensors (not NumPy arrays)
+  - The first dimension is the number of parallel environments
+  - Rewards may be torch tensors
+  - render() may return a torch tensor
+
+These tests use a lightweight mock environment to verify the wrapper
+handles these edge cases correctly, without requiring a GPU or Isaac Lab.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+import gymnasium as gym
+from gymnasium import spaces
+
+from roboharness.wrappers import RobotHarnessWrapper
+
+pytestmark = pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+
+
+class MockIsaacLabEnv(gym.Env):
+    """Mock environment that mimics Isaac Lab's tensor-based interface.
+
+    Isaac Lab envs inherit from gymnasium.Env but return torch tensors
+    instead of numpy arrays, and the first dimension is num_envs.
+    """
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 60}
+
+    def __init__(self, num_envs: int = 1, render_mode: str = "rgb_array"):
+        super().__init__()
+        self.num_envs = num_envs
+        self.render_mode = render_mode
+        self._step_count = 0
+
+        # Isaac Lab uses Box spaces but actual data is torch tensors
+        obs_dim = 12  # typical for reach tasks (joint pos + target pos)
+        act_dim = 7  # 7-DOF arm
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(obs_dim,), dtype=np.float32
+        )
+        self.action_space = spaces.Box(
+            low=-1.0, high=1.0, shape=(act_dim,), dtype=np.float32
+        )
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[Any, dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        self._step_count = 0
+        obs = torch.zeros(self.num_envs, *self.observation_space.shape)
+        return obs, {}
+
+    def step(self, action: Any) -> tuple[Any, Any, Any, Any, dict[str, Any]]:
+        self._step_count += 1
+        obs = torch.randn(self.num_envs, *self.observation_space.shape)
+        reward = torch.tensor([0.5] * self.num_envs)
+        terminated = torch.tensor([False] * self.num_envs)
+        truncated = torch.tensor([False] * self.num_envs)
+        return obs, reward, terminated, truncated, {}
+
+    def render(self) -> np.ndarray:
+        # Isaac Lab's render typically returns numpy RGB array even though obs are tensors
+        return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+class MockIsaacLabEnvDictObs(MockIsaacLabEnv):
+    """Mock Isaac Lab env with dict observation space (common for RL tasks)."""
+
+    def __init__(self, num_envs: int = 1, render_mode: str = "rgb_array"):
+        super().__init__(num_envs=num_envs, render_mode=render_mode)
+        self.observation_space = spaces.Dict(
+            {
+                "policy": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(12,), dtype=np.float32
+                ),
+            }
+        )
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[Any, dict[str, Any]]:
+        gym.Env.reset(self, seed=seed, options=options)
+        self._step_count = 0
+        obs = {"policy": torch.zeros(self.num_envs, 12)}
+        return obs, {}
+
+    def step(self, action: Any) -> tuple[Any, Any, Any, Any, dict[str, Any]]:
+        self._step_count += 1
+        obs = {"policy": torch.randn(self.num_envs, 12)}
+        reward = torch.tensor([0.5] * self.num_envs)
+        terminated = torch.tensor([False] * self.num_envs)
+        truncated = torch.tensor([False] * self.num_envs)
+        return obs, reward, terminated, truncated, {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_with_torch_tensor_obs(tmp_path):
+    """Wrapper should pass through torch tensor observations unchanged."""
+    env = MockIsaacLabEnv(num_envs=1)
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=[{"name": "cp1", "step": 5}],
+        output_dir=tmp_path,
+    )
+    obs, info = wrapped.reset()
+    assert isinstance(obs, torch.Tensor)
+
+    for _ in range(5):
+        obs, reward, terminated, truncated, info = wrapped.step(
+            torch.zeros(1, *env.action_space.shape)
+        )
+    assert isinstance(obs, torch.Tensor)
+
+
+def test_wrapper_checkpoint_with_torch_reward(tmp_path):
+    """Checkpoint state.json should handle torch tensor rewards."""
+    env = MockIsaacLabEnv(num_envs=1)
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=[{"name": "cp1", "step": 3}],
+        output_dir=tmp_path,
+    )
+    wrapped.reset()
+    for _ in range(3):
+        obs, reward, terminated, truncated, info = wrapped.step(
+            torch.zeros(1, *env.action_space.shape)
+        )
+
+    assert "checkpoint" in info
+    assert info["checkpoint"]["name"] == "cp1"
+
+    # Verify state.json was written and is valid
+    import json
+    from pathlib import Path
+
+    state_path = Path(info["checkpoint"]["files"]["state"])
+    state = json.loads(state_path.read_text())
+    assert state["checkpoint"] == "cp1"
+    assert state["step"] == 3
+
+
+def test_wrapper_with_dict_observations(tmp_path):
+    """Wrapper should handle dict observations (common in Isaac Lab)."""
+    env = MockIsaacLabEnvDictObs(num_envs=1)
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=[{"name": "cp1", "step": 2}],
+        output_dir=tmp_path,
+    )
+    obs, info = wrapped.reset()
+    assert isinstance(obs, dict)
+    assert "policy" in obs
+
+    for _ in range(2):
+        obs, reward, terminated, truncated, info = wrapped.step(
+            torch.zeros(1, *env.action_space.shape)
+        )
+    assert isinstance(obs, dict)
+    assert "checkpoint" in info
+
+    # Verify state.json records obs_keys for dict obs
+    import json
+    from pathlib import Path
+
+    state_path = Path(info["checkpoint"]["files"]["state"])
+    state = json.loads(state_path.read_text())
+    assert "obs_keys" in state
+    assert "policy" in state["obs_keys"]
+
+
+def test_wrapper_with_multi_env(tmp_path):
+    """Wrapper should work with vectorized envs (num_envs > 1)."""
+    env = MockIsaacLabEnv(num_envs=4)
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=[{"name": "cp1", "step": 1}],
+        output_dir=tmp_path,
+    )
+    obs, _ = wrapped.reset()
+    assert obs.shape[0] == 4
+
+    obs, reward, terminated, truncated, info = wrapped.step(
+        torch.zeros(4, *env.action_space.shape)
+    )
+    assert obs.shape[0] == 4
+    assert "checkpoint" in info
+
+
+def test_wrapper_render_capture_saved(tmp_path):
+    """Wrapper should save render output as PNG at checkpoints."""
+    env = MockIsaacLabEnv(num_envs=1)
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=[{"name": "init", "step": 1}],
+        output_dir=tmp_path,
+        task_name="test_isaac",
+    )
+    wrapped.reset()
+    obs, reward, terminated, truncated, info = wrapped.step(
+        torch.zeros(1, *env.action_space.shape)
+    )
+    assert "checkpoint" in info
+    capture_dir = tmp_path / "test_isaac" / "trial_001" / "init"
+    assert capture_dir.exists()
+    assert (capture_dir / "state.json").exists()
+    assert (capture_dir / "metadata.json").exists()


### PR DESCRIPTION
Add Isaac Lab integration example script and fix RobotHarnessWrapper to
handle PyTorch tensor observations/rewards from Isaac Lab environments.
CPU-only mock tests validate the wrapper without requiring a GPU.

- Add examples/isaac_lab_integration.py with Isaac-Reach-Franka-v0 demo
- Add tests/test_isaac_lab_compat.py with mock Isaac Lab env (torch tensors)
- Fix reward serialization for torch tensors (scalar and vectorized)
- Fix obs shape/dtype logging for non-numpy array-like objects

https://claude.ai/code/session_01P8uZzJsrHadhhyHinNwEh3