### PR TITLE
fix: guard gymnasium import in isaac lab tests and harden CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,25 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package with dev dependencies
         run: pip install -e ".[dev]"
+      - name: Verify test collection (catch missing imports early)
+        run: pytest --collect-only -q
       - name: Run tests
+        run: pytest
+
+  test-mujoco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install system dependencies (OSMesa for headless rendering)
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
+      - name: Install package with MuJoCo backend and dev dependencies
+        run: pip install -e ".[mujoco,dev]" Pillow
+      - name: Run tests (including MuJoCo-dependent tests)
+        env:
+          MUJOCO_GL: osmesa
         run: pytest
 
   mujoco-example:

--- a/tests/test_isaac_lab_compat.py
+++ b/tests/test_isaac_lab_compat.py
@@ -17,19 +17,12 @@ from typing import Any
 import numpy as np
 import pytest
 
-try:
-    import torch
+torch = pytest.importorskip("torch", reason="PyTorch not installed")
+gym = pytest.importorskip("gymnasium", reason="gymnasium not installed")
 
-    HAS_TORCH = True
-except ImportError:
-    HAS_TORCH = False
+from gymnasium import spaces  # noqa: E402
 
-import gymnasium as gym
-from gymnasium import spaces
-
-from roboharness.wrappers import RobotHarnessWrapper
-
-pytestmark = pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not installed")
+from roboharness.wrappers import RobotHarnessWrapper  # noqa: E402
 
 
 class MockIsaacLabEnv(gym.Env):


### PR DESCRIPTION
- Use pytest.importorskip for torch and gymnasium in test_isaac_lab_compat.py
  so the module is cleanly skipped instead of crashing during collection
- Add `pytest --collect-only` step to CI test job to catch import errors early
- Add dedicated test-mujoco CI job that runs full test suite with MuJoCo
  installed (headless via OSMesa), so visualizer tests actually execute in CI

https://claude.ai/code/session_01Y51ftEo2R571bp9HpZEwE1