### PR TITLE
fix: correct GitHub Pages URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ python examples/mujoco_grasp.py --report
 
 This runs a scripted grasp sequence, captures multi-view screenshots at each checkpoint, and generates an HTML report. See [`examples/mujoco_grasp.py`](examples/mujoco_grasp.py) for the full source.
 
-> **[View the interactive visual report online](https://miaodx.github.io/RobotHarness/)** — auto-generated from CI on every push to main.
+> **[View the interactive visual report online](https://miaodx.com/roboharness/)** — auto-generated from CI on every push to main.
 
 **Checkpoint captures (front view):**
 


### PR DESCRIPTION
## Summary
- Fix Pages link in README: `miaodx.github.io/RobotHarness/` → `miaodx.com/roboharness/`
- The old URL was returning 404 due to case mismatch

## Test plan
- [x] Verified `https://miaodx.com/roboharness/` loads correctly with both demo cards

https://claude.ai/code/session_01Eczs44NYfLV5HQVFdXU44Z