### PR TITLE
Add optional Rerun `.rrd` capture logging to Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ pip install roboharness
 # With MuJoCo + Meshcat backend
 pip install roboharness[mujoco]
 
+# With Rerun logging (.rrd)
+pip install roboharness[rerun]
+
 # Development
 pip install roboharness[dev]
 ```
@@ -123,7 +126,12 @@ backend = MuJoCoMeshcatBackend(
     model_path="robot.xml",
     cameras=["front", "side", "top"],
 )
-harness = Harness(backend, output_dir="./harness_output", task_name="pick_and_place")
+harness = Harness(
+    backend,
+    output_dir="./harness_output",
+    task_name="pick_and_place",
+    enable_rerun=True,  # optional: also save capture.rrd per trial
+)
 
 harness.add_checkpoint("pre_grasp", cameras=["front", "side", "top"])
 harness.add_checkpoint("contact", cameras=["front", "wrist"])

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -43,11 +43,12 @@
 - 用 ManiSkill 的 `PickCube-v1` + `CPUGymWrapper` 测试
 - 写 `examples/maniskill_integration.py`
 
-### 6. Rerun 集成 — [#6](https://github.com/MiaoDX/RobotHarness/issues/6)
+### ~~6. Rerun 集成~~ ✅ — [#6](https://github.com/MiaoDX/RobotHarness/issues/6)
 
-- 在 capture 阶段同时写入 Rerun `.rrd` 文件
-- 利用 Rerun 的 Blueprint 定义标准化的调试布局
+- ~~在 capture 阶段同时写入 Rerun `.rrd` 文件~~
+- ~~利用 Rerun 的 Blueprint 定义标准化的调试布局~~
 - 可作为给 Rerun 社区提交的 example 来增加曝光
+- 已完成：`Harness(enable_rerun=True)` 会在每个 trial 下输出 `capture.rrd`，并设置默认 Blueprint 布局
 
 ## P2 — 项目工程化（提升专业度）
 
@@ -97,3 +98,4 @@
 | 2026-04-02 | 项目骨架：pyproject.toml, 核心模块, Gymnasium Wrapper, GraspTaskStore, 22 个测试, 文档英文化 |
 | 2026-04-02 | Demo GIF：两组抓取任务 front view GIF 嵌入 README（P0-1 ✅） |
 | 2026-04-02 | Issues 跟踪：将 TODO 项关联至 GitHub Issues #2-#12 |
+| 2026-04-02 | Rerun 集成：Capture 阶段支持 `.rrd` 录制 + 默认 Blueprint（P1-6 ✅） |

--- a/src/roboharness/core/harness.py
+++ b/src/roboharness/core/harness.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from roboharness.core.capture import CameraView, CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore
+from roboharness.core.rerun_logger import RerunCaptureLogger
 
 
 @runtime_checkable
@@ -73,6 +74,8 @@ class Harness:
         backend: SimulatorBackend,
         output_dir: str | Path = "./harness_output",
         task_name: str = "default",
+        enable_rerun: bool = False,
+        rerun_app_id: str = "roboharness",
     ):
         self.backend = backend
         self.output_dir = Path(output_dir)
@@ -82,6 +85,7 @@ class Harness:
         self._step_count: int = 0
         self._trial_count: int = 0
         self._checkpoint_store = CheckpointStore(self.output_dir / "snapshots")
+        self._rerun_logger = RerunCaptureLogger(app_id=rerun_app_id) if enable_rerun else None
 
     # ---- Checkpoint management ----
 
@@ -110,6 +114,8 @@ class Harness:
         self._step_count = 0
         self._current_checkpoint_idx = 0
         self._trial_count += 1
+        if self._rerun_logger is not None:
+            self._rerun_logger.configure_trial(self._trial_dir(), self.task_name)
         return self.backend.reset()
 
     def step(self, action: Any) -> dict[str, Any]:
@@ -165,18 +171,24 @@ class Harness:
         state = self.backend.get_state()
         sim_time = self.backend.get_sim_time()
 
+        capture_meta = {"trial": self._trial_count, "task": self.task_name}
+        if self._rerun_logger is not None and self._rerun_logger.rrd_path is not None:
+            capture_meta["rerun_rrd"] = str(self._rerun_logger.rrd_path)
+
         result = CaptureResult(
             checkpoint_name=cp_name,
             step=self._step_count,
             sim_time=sim_time,
             views=views,
             state=state,
-            metadata={"trial": self._trial_count, "task": self.task_name},
+            metadata=capture_meta,
         )
 
         # Save to disk
         capture_dir = self._trial_dir() / cp_name
         result.save(capture_dir)
+        if self._rerun_logger is not None:
+            self._rerun_logger.log_capture(result)
 
         return result
 

--- a/src/roboharness/core/rerun_logger.py
+++ b/src/roboharness/core/rerun_logger.py
@@ -1,0 +1,118 @@
+"""Optional Rerun logging for capture artifacts."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from roboharness.core.capture import CameraView, CaptureResult
+
+
+class RerunCaptureLogger:
+    """Logs captures to a per-trial `.rrd` file when rerun-sdk is installed."""
+
+    def __init__(self, app_id: str = "roboharness") -> None:
+        self._app_id = app_id
+        self._rr: Any | None = None
+        self._rrd_path: Path | None = None
+
+    @property
+    def active(self) -> bool:
+        return self._rr is not None and self._rrd_path is not None
+
+    @property
+    def rrd_path(self) -> Path | None:
+        return self._rrd_path
+
+    def configure_trial(self, trial_dir: Path, task_name: str) -> Path | None:
+        """Initialize rerun recording for a trial.
+
+        Returns the `.rrd` output path if rerun-sdk is available, otherwise None.
+        """
+        rr = self._import_rerun()
+        if rr is None:
+            self._rr = None
+            self._rrd_path = None
+            return None
+
+        trial_dir.mkdir(parents=True, exist_ok=True)
+        rrd_path = trial_dir / "capture.rrd"
+
+        rr.init(f"{self._app_id}.{task_name}", spawn=False)
+        rr.save(str(rrd_path))
+        self._rr = rr
+        self._rrd_path = rrd_path
+        self._log_default_blueprint()
+        return rrd_path
+
+    def log_capture(self, capture: CaptureResult) -> None:
+        """Append one checkpoint capture frame to rerun recording."""
+        if self._rr is None:
+            return
+
+        rr = self._rr
+        rr.set_time_sequence("sim_step", capture.step)
+        rr.set_time_seconds("sim_time", capture.sim_time)
+
+        rr.log("harness/checkpoint", rr.TextDocument(capture.checkpoint_name))
+        rr.log("harness/state", rr.TextDocument(_as_json_text(capture.state)))
+
+        for view in capture.views:
+            self._log_view(view)
+
+    def _log_view(self, view: CameraView) -> None:
+        assert self._rr is not None
+        rr = self._rr
+        base = f"camera/{view.name}"
+        rr.log(f"{base}/rgb", rr.Image(view.rgb))
+
+        if view.depth is not None:
+            depth = view.depth.astype(np.float32, copy=False)
+            depth_image = rr.DepthImage(depth) if hasattr(rr, "DepthImage") else rr.Image(depth)
+            rr.log(f"{base}/depth", depth_image)
+
+        if view.segmentation is not None:
+            seg = view.segmentation.astype(np.uint16, copy=False)
+            seg_image = (
+                rr.SegmentationImage(seg) if hasattr(rr, "SegmentationImage") else rr.Image(seg)
+            )
+            rr.log(f"{base}/segmentation", seg_image)
+
+    def _log_default_blueprint(self) -> None:
+        """Best-effort standard debug layout.
+
+        Uses rerun.blueprint when available. Compatible no-op if APIs change.
+        """
+        assert self._rr is not None
+        rr = self._rr
+
+        if not hasattr(rr, "blueprint") or not hasattr(rr, "send_blueprint"):
+            return
+
+        bp = rr.blueprint
+        required = ("Blueprint", "Horizontal", "Spatial2D", "TextDocumentView")
+        if not all(hasattr(bp, name) for name in required):
+            return
+
+        blueprint = bp.Blueprint(
+            bp.Horizontal(
+                bp.Spatial2D(origin="/camera"),
+                bp.TextDocumentView(origin="/harness"),
+            )
+        )
+        rr.send_blueprint(blueprint)
+
+    @staticmethod
+    def _import_rerun() -> Any | None:
+        try:
+            return importlib.import_module("rerun")
+        except ImportError:
+            return None
+
+
+def _as_json_text(payload: dict[str, Any]) -> str:
+    parts = [f'"{key}": {value!r}' for key, value in sorted(payload.items())]
+    return "{\n  " + ",\n  ".join(parts) + "\n}"

--- a/tests/test_rerun_logger.py
+++ b/tests/test_rerun_logger.py
@@ -1,0 +1,101 @@
+"""Tests for optional Rerun capture logging."""
+
+from __future__ import annotations
+
+import sys
+
+from roboharness.core.harness import Harness
+from tests.test_harness import MockBackend
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def init(self, app_id: str, spawn: bool = False) -> None:
+        self.calls.append(("init", app_id, spawn))
+
+    def save(self, path: str) -> None:
+        self.calls.append(("save", path))
+
+    def set_time_sequence(self, name: str, value: int) -> None:
+        self.calls.append(("set_time_sequence", name, value))
+
+    def set_time_seconds(self, name: str, value: float) -> None:
+        self.calls.append(("set_time_seconds", name, value))
+
+    def log(self, path: str, obj: object) -> None:
+        self.calls.append(("log", path, type(obj).__name__))
+
+    def send_blueprint(self, _bp: object) -> None:
+        self.calls.append(("send_blueprint",))
+
+    class Image:
+        def __init__(self, _arr):
+            pass
+
+    class DepthImage:
+        def __init__(self, _arr):
+            pass
+
+    class SegmentationImage:
+        def __init__(self, _arr):
+            pass
+
+    class TextDocument:
+        def __init__(self, _text: str):
+            pass
+
+
+class _BlueprintNS:
+    class Blueprint:
+        def __init__(self, _inner: object):
+            pass
+
+    class Horizontal:
+        def __init__(self, *_views: object):
+            pass
+
+    class Spatial2D:
+        def __init__(self, origin: str):
+            self.origin = origin
+
+    class TextDocumentView:
+        def __init__(self, origin: str):
+            self.origin = origin
+
+
+def test_harness_rerun_logs_when_sdk_present(tmp_path, monkeypatch):
+    rr = _Recorder()
+    rr.blueprint = _BlueprintNS
+    monkeypatch.setitem(sys.modules, "rerun", rr)
+
+    harness = Harness(
+        MockBackend(),
+        output_dir=tmp_path,
+        task_name="demo",
+        enable_rerun=True,
+        rerun_app_id="testapp",
+    )
+    harness.add_checkpoint("cp1", cameras=["front"])
+    harness.reset()
+
+    result = harness.run_to_next_checkpoint([None, None])
+
+    assert result is not None
+    assert any(call[0] == "save" and call[1].endswith("capture.rrd") for call in rr.calls)
+    assert any(call[:2] == ("log", "camera/front/rgb") for call in rr.calls)
+    assert result.metadata["rerun_rrd"].endswith("capture.rrd")
+
+
+def test_harness_rerun_gracefully_disabled_when_sdk_missing(tmp_path, monkeypatch):
+    monkeypatch.delitem(sys.modules, "rerun", raising=False)
+
+    harness = Harness(MockBackend(), output_dir=tmp_path, enable_rerun=True)
+    harness.add_checkpoint("cp1", cameras=["front"])
+    harness.reset()
+
+    result = harness.run_to_next_checkpoint([None])
+
+    assert result is not None
+    assert "rerun_rrd" not in result.metadata


### PR DESCRIPTION
### Motivation

- Provide issue #6 Rerun integration so captures can be recorded as `.rrd` files for time-scrubbable visualization and sharing.
- Make Rerun support optional so projects without `rerun-sdk` remain functional and the feature only activates when requested.

### Description

- Add `RerunCaptureLogger` in `src/roboharness/core/rerun_logger.py` that lazily imports `rerun`, creates a per-trial `capture.rrd`, logs checkpoint/state text and camera RGB/depth/segmentation, and publishes a best-effort default Blueprint when available. 
- Wire the logger into `Harness` by adding `enable_rerun: bool` and `rerun_app_id: str` constructor arguments, configuring a trial on `reset()` and calling `log_capture()` after each `capture()`. 
- Include the emitted Rerun file path under `metadata['rerun_rrd']` when recording is active. 
- Add `tests/test_rerun_logger.py` covering SDK-present and SDK-missing flows, and update `README.md` and `docs/todo.md` to document installation and mark the TODO as completed.

### Testing

- Ran lint checks with `ruff check src tests` and the checks passed. 
- Ran the test suite with `PYTHONPATH=src pytest -q`, which completed successfully with `29 passed, 5 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8b166014832daae8c296d484b4d7)