### PR TITLE
fix: improve G1 visualization — wider camera views and mesh support in Meshcat

### DIFF
--- a/examples/g1_wbc_reach.py
+++ b/examples/g1_wbc_reach.py
@@ -75,10 +75,10 @@ def build_scene_xml() -> str:
     <light pos="-1 1 3" dir="0.3 -0.3 -1" diffuse="0.4 0.4 0.4"/>
 
     <!-- Cameras -->
-    <camera name="front" pos="1.8 0 1.0" xyaxes="0 1 0 -0.3 0 1"/>
-    <camera name="side" pos="0 2.0 1.0" xyaxes="-1 0 0 0 -0.3 1"/>
-    <camera name="top" pos="0 0 3.0" xyaxes="1 0 0 0 1 0"/>
-    <camera name="close_up" pos="0.7 0.3 1.1" xyaxes="-0.4 1 0 -0.3 -0.1 1"/>
+    <camera name="front" pos="2.8 0 1.0" xyaxes="0 1 0 -0.2 0 1"/>
+    <camera name="side" pos="0 3.0 1.0" xyaxes="-1 0 0 0 -0.2 1"/>
+    <camera name="top" pos="0 0 4.5" xyaxes="1 0 0 0 1 0"/>
+    <camera name="close_up" pos="1.2 0.5 1.2" xyaxes="-0.4 1 0 -0.2 -0.1 1"/>
 
     <!-- Table in front of robot -->
     <body name="table" pos="0.45 0 0.35">

--- a/src/roboharness/backends/visualizer.py
+++ b/src/roboharness/backends/visualizer.py
@@ -151,26 +151,24 @@ class MeshcatVisualizer:
                 transparent=bool(rgba[3] < 1.0),
             )
 
-            geometry = self._make_geometry(geom_type, geom_size)
+            geometry = self._make_geometry(geom_type, geom_size, geom_id=i)
             if geometry is not None:
                 self._vis[path].set_object(geometry, material)
 
         # Initial transform sync
         self.sync()
 
-    def _make_geometry(self, geom_type: int, size: np.ndarray) -> Any:
+    def _make_geometry(self, geom_type: int, size: np.ndarray, geom_id: int = -1) -> Any:
         """Create a Meshcat geometry object matching a MuJoCo geom type."""
         import meshcat.geometry as g
 
         # MuJoCo geom type constants (mjtGeom enum)
         _PLANE = 0
-        _HFIELD = 1  # noqa: F841
         _SPHERE = 2
         _CAPSULE = 3
-        _ELLIPSOID = 4  # noqa: F841
         _CYLINDER = 5
         _BOX = 6
-        _MESH = 7  # noqa: F841
+        _MESH = 7
 
         if geom_type == _PLANE:
             return g.Box([2.0, 2.0, 0.001])
@@ -186,9 +184,29 @@ class MeshcatVisualizer:
             return g.Cylinder(2 * half_length, radius)
         elif geom_type == _BOX:
             return g.Box([2 * float(size[0]), 2 * float(size[1]), 2 * float(size[2])])
+        elif geom_type == _MESH and geom_id >= 0:
+            return self._make_mesh_geometry(geom_id)
         else:
-            # Unsupported geom type — skip
             return None
+
+    def _make_mesh_geometry(self, geom_id: int) -> Any:
+        """Extract mesh vertices/faces from MuJoCo model for a mesh geom."""
+        import meshcat.geometry as g
+
+        model = self._model
+        mesh_id = model.geom_dataid[geom_id]
+        if mesh_id < 0:
+            return None
+
+        vert_start = model.mesh_vertadr[mesh_id]
+        vert_count = model.mesh_vertnum[mesh_id]
+        face_start = model.mesh_faceadr[mesh_id]
+        face_count = model.mesh_facenum[mesh_id]
+
+        vertices = model.mesh_vert[vert_start : vert_start + vert_count].copy()
+        faces = model.mesh_face[face_start : face_start + face_count].copy()
+
+        return g.TriangularMeshGeometry(vertices=vertices, faces=faces)
 
     # ------------------------------------------------------------------
     # State synchronization


### PR DESCRIPTION
Camera positions moved further from robot so all views capture the full body.
Added mesh geom support to MeshcatVisualizer so the robot's mesh body parts
render in the interactive 3D viewer instead of only showing primitives.

https://claude.ai/code/session_01BchEeFrQ4YR8nxCpFCceqA