### PR TITLE
feat: add parallel trial execution for throughput scaling

### DIFF
--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -6,11 +6,15 @@ from roboharness.core.capture import CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore
 from roboharness.core.controller import Controller
 from roboharness.core.harness import Harness
+from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
 
 __all__ = [
+    "BatchResult",
     "CaptureResult",
     "Checkpoint",
     "CheckpointStore",
     "Controller",
     "Harness",
+    "ParallelTrialRunner",
+    "TrialSpec",
 ]

--- a/src/roboharness/runner.py
+++ b/src/roboharness/runner.py
@@ -1,0 +1,200 @@
+"""Parallel trial execution for throughput scaling.
+
+Enables concurrent trial execution with isolated simulator instances,
+configurable concurrency, and cross-trial result aggregation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from roboharness.core.harness import SimulatorBackend
+from roboharness.storage.task_store import TaskStore, TrialResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TrialSpec:
+    """Specification for a single trial to execute.
+
+    Attributes:
+        variant_name: Name of the task variant (e.g., "grasp_position_001").
+        trial_id: Unique trial identifier within the variant.
+        metadata: Arbitrary per-trial configuration passed to the trial function.
+    """
+
+    variant_name: str
+    trial_id: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+#: Callable that runs a single trial given an isolated backend and output directory.
+#: Returns a TrialResult describing the outcome.
+TrialFn = Callable[[SimulatorBackend, Path, TrialSpec], TrialResult]
+
+
+@dataclass
+class BatchResult:
+    """Aggregated results across multiple parallel trials."""
+
+    results: list[TrialResult]
+    specs: list[TrialSpec]
+    total_duration: float
+
+    @property
+    def total_trials(self) -> int:
+        return len(self.results)
+
+    @property
+    def successful_trials(self) -> int:
+        return sum(1 for r in self.results if r.success)
+
+    @property
+    def failed_trials(self) -> int:
+        return self.total_trials - self.successful_trials
+
+    @property
+    def success_rate(self) -> float:
+        if self.total_trials == 0:
+            return 0.0
+        return self.successful_trials / self.total_trials
+
+    def per_variant_summary(self) -> dict[str, dict[str, Any]]:
+        """Compute per-variant success rates and statistics."""
+        variant_results: dict[str, list[TrialResult]] = defaultdict(list)
+        for spec, result in zip(self.specs, self.results, strict=True):
+            variant_results[spec.variant_name].append(result)
+
+        summaries: dict[str, dict[str, Any]] = {}
+        for variant, results in variant_results.items():
+            successes = [r for r in results if r.success]
+            durations = [r.duration for r in results if r.duration > 0]
+            summaries[variant] = {
+                "total_trials": len(results),
+                "successful_trials": len(successes),
+                "success_rate": len(successes) / len(results) if results else 0.0,
+                "mean_duration": sum(durations) / len(durations) if durations else 0.0,
+            }
+        return summaries
+
+    def failure_phase_distribution(self) -> dict[str, int]:
+        """Count how many trials failed at each checkpoint phase.
+
+        Uses the last checkpoint reached before failure to determine the phase.
+        Trials that failed before reaching any checkpoint are counted under
+        "before_first_checkpoint".
+        """
+        distribution: dict[str, int] = defaultdict(int)
+        for result in self.results:
+            if result.success:
+                continue
+            if result.checkpoints_reached:
+                last_phase = result.checkpoints_reached[-1]
+            else:
+                last_phase = "before_first_checkpoint"
+            distribution[last_phase] += 1
+        return dict(distribution)
+
+    def summary(self) -> dict[str, Any]:
+        """Generate a complete summary dict suitable for JSON serialization."""
+        return {
+            "total_trials": self.total_trials,
+            "successful_trials": self.successful_trials,
+            "failed_trials": self.failed_trials,
+            "success_rate": self.success_rate,
+            "total_duration": self.total_duration,
+            "per_variant": self.per_variant_summary(),
+            "failure_phase_distribution": self.failure_phase_distribution(),
+        }
+
+
+class ParallelTrialRunner:
+    """Runs trials concurrently with isolated simulator instances.
+
+    Each trial receives its own ``SimulatorBackend`` (created by the factory)
+    and its own output directory (managed by the ``TaskStore``). No mutable
+    state is shared between concurrent trials.
+
+    Usage::
+
+        def my_trial(backend, output_dir, spec):
+            harness = Harness(backend, output_dir=output_dir)
+            harness.add_checkpoint("pre_grasp", cameras=["front"])
+            harness.reset()
+            result = harness.run_to_next_checkpoint(actions)
+            return TrialResult(trial_id=spec.trial_id, success=True)
+
+        runner = ParallelTrialRunner(
+            backend_factory=lambda: MyBackend(),
+            store=my_store,
+            max_workers=4,
+        )
+        batch = runner.run(specs, trial_fn=my_trial)
+        print(batch.success_rate)
+    """
+
+    def __init__(
+        self,
+        backend_factory: Callable[[], SimulatorBackend],
+        store: TaskStore,
+        max_workers: int = 4,
+    ):
+        self.backend_factory = backend_factory
+        self.store = store
+        self.max_workers = max_workers
+
+    def run(self, specs: list[TrialSpec], trial_fn: TrialFn) -> BatchResult:
+        """Execute trials in parallel.
+
+        Args:
+            specs: List of trial specifications to execute.
+            trial_fn: Callable receiving ``(backend, output_dir, spec)`` that
+                runs a single trial and returns a ``TrialResult``.
+
+        Returns:
+            Aggregated ``BatchResult`` with per-trial and per-variant statistics.
+        """
+        start = time.monotonic()
+        # Maintain insertion order so results[i] corresponds to specs[i].
+        results: list[TrialResult | None] = [None] * len(specs)
+
+        with ThreadPoolExecutor(max_workers=min(self.max_workers, len(specs))) as executor:
+            future_to_idx = {
+                executor.submit(self._run_one, spec, trial_fn): i for i, spec in enumerate(specs)
+            }
+            for future in as_completed(future_to_idx):
+                idx = future_to_idx[future]
+                spec = specs[idx]
+                try:
+                    result = future.result()
+                except Exception as exc:
+                    logger.error("Trial %s/%d raised: %s", spec.variant_name, spec.trial_id, exc)
+                    result = TrialResult(
+                        trial_id=spec.trial_id,
+                        success=False,
+                        reason=f"Unhandled exception: {exc}",
+                    )
+                results[idx] = result
+                self.store.save_trial_result(spec.variant_name, result)
+
+        total_duration = time.monotonic() - start
+        # All slots should be filled; the cast is safe.
+        return BatchResult(
+            results=[r for r in results if r is not None],
+            specs=list(specs),
+            total_duration=total_duration,
+        )
+
+    def _run_one(self, spec: TrialSpec, trial_fn: TrialFn) -> TrialResult:
+        """Create an isolated environment and execute one trial."""
+        backend = self.backend_factory()
+        output_dir = self.store.get_trial_dir(spec.variant_name, spec.trial_id)
+        return trial_fn(backend, output_dir, spec)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,334 @@
+"""Tests for parallel trial execution."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from roboharness.core.capture import CameraView
+from roboharness.core.harness import Harness, SimulatorBackend
+from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
+from roboharness.storage.task_store import TaskStore, TrialResult
+
+
+class MockBackend:
+    """Thread-safe mock backend for parallel testing."""
+
+    def __init__(self) -> None:
+        self._time = 0.0
+        self._state: dict[str, Any] = {"qpos": [0.0], "qvel": [0.0]}
+
+    def step(self, action: Any) -> dict[str, Any]:
+        self._time += 0.01
+        return self.get_state()
+
+    def get_state(self) -> dict[str, Any]:
+        return {**self._state, "time": self._time}
+
+    def save_state(self) -> dict[str, Any]:
+        return {"state": {**self._state}, "time": self._time}
+
+    def restore_state(self, state: dict[str, Any]) -> None:
+        self._state = {**state["state"]}
+        self._time = state["time"]
+
+    def capture_camera(self, camera_name: str) -> CameraView:
+        return CameraView(name=camera_name, rgb=np.zeros((64, 64, 3), dtype=np.uint8))
+
+    def get_sim_time(self) -> float:
+        return self._time
+
+    def reset(self) -> dict[str, Any]:
+        self._time = 0.0
+        self._state = {"qpos": [0.0], "qvel": [0.0]}
+        return self.get_state()
+
+
+# -- TrialSpec tests --
+
+
+def test_trial_spec_defaults():
+    spec = TrialSpec(variant_name="v1", trial_id=1)
+    assert spec.variant_name == "v1"
+    assert spec.trial_id == 1
+    assert spec.metadata == {}
+
+
+def test_trial_spec_with_metadata():
+    spec = TrialSpec(variant_name="v1", trial_id=2, metadata={"key": "value"})
+    assert spec.metadata["key"] == "value"
+
+
+# -- BatchResult tests --
+
+
+def test_batch_result_empty():
+    batch = BatchResult(results=[], specs=[], total_duration=0.0)
+    assert batch.total_trials == 0
+    assert batch.success_rate == 0.0
+    assert batch.failure_phase_distribution() == {}
+
+
+def test_batch_result_success_rate():
+    results = [
+        TrialResult(trial_id=1, success=True),
+        TrialResult(trial_id=2, success=False, reason="fell"),
+        TrialResult(trial_id=3, success=True),
+    ]
+    specs = [
+        TrialSpec(variant_name="v1", trial_id=1),
+        TrialSpec(variant_name="v1", trial_id=2),
+        TrialSpec(variant_name="v2", trial_id=3),
+    ]
+    batch = BatchResult(results=results, specs=specs, total_duration=1.0)
+    assert batch.total_trials == 3
+    assert batch.successful_trials == 2
+    assert batch.failed_trials == 1
+    assert batch.success_rate == 2 / 3
+
+
+def test_batch_result_per_variant_summary():
+    results = [
+        TrialResult(trial_id=1, success=True, duration=1.0),
+        TrialResult(trial_id=2, success=False, duration=0.5),
+        TrialResult(trial_id=3, success=True, duration=2.0),
+    ]
+    specs = [
+        TrialSpec(variant_name="v1", trial_id=1),
+        TrialSpec(variant_name="v1", trial_id=2),
+        TrialSpec(variant_name="v2", trial_id=3),
+    ]
+    batch = BatchResult(results=results, specs=specs, total_duration=3.0)
+    summary = batch.per_variant_summary()
+
+    assert summary["v1"]["total_trials"] == 2
+    assert summary["v1"]["successful_trials"] == 1
+    assert summary["v1"]["success_rate"] == 0.5
+    assert summary["v1"]["mean_duration"] == 0.75
+
+    assert summary["v2"]["total_trials"] == 1
+    assert summary["v2"]["success_rate"] == 1.0
+
+
+def test_batch_result_failure_phase_distribution():
+    results = [
+        TrialResult(trial_id=1, success=False, checkpoints_reached=["pre_grasp", "contact"]),
+        TrialResult(trial_id=2, success=False, checkpoints_reached=["pre_grasp"]),
+        TrialResult(trial_id=3, success=False, checkpoints_reached=[]),
+        TrialResult(trial_id=4, success=True, checkpoints_reached=["pre_grasp", "contact", "lift"]),
+    ]
+    specs = [TrialSpec(variant_name="v1", trial_id=i) for i in range(1, 5)]
+    batch = BatchResult(results=results, specs=specs, total_duration=1.0)
+    dist = batch.failure_phase_distribution()
+
+    assert dist["contact"] == 1
+    assert dist["pre_grasp"] == 1
+    assert dist["before_first_checkpoint"] == 1
+    assert "lift" not in dist  # trial 4 succeeded
+
+
+def test_batch_result_summary_keys():
+    batch = BatchResult(
+        results=[TrialResult(trial_id=1, success=True)],
+        specs=[TrialSpec(variant_name="v1", trial_id=1)],
+        total_duration=0.5,
+    )
+    s = batch.summary()
+    assert "total_trials" in s
+    assert "success_rate" in s
+    assert "per_variant" in s
+    assert "failure_phase_distribution" in s
+    assert "total_duration" in s
+
+
+# -- ParallelTrialRunner tests --
+
+
+def _simple_trial_fn(backend: SimulatorBackend, output_dir: Path, spec: TrialSpec) -> TrialResult:
+    """A minimal trial function that runs a few steps and succeeds."""
+    backend.reset()
+    for _ in range(3):
+        backend.step(np.zeros(3))
+    return TrialResult(
+        trial_id=spec.trial_id,
+        success=True,
+        reason="completed",
+        duration=0.1,
+        checkpoints_reached=["phase_a"],
+    )
+
+
+def test_parallel_runner_single_trial(tmp_path: Path):
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=1,
+    )
+    specs = [TrialSpec(variant_name="v1", trial_id=1)]
+    batch = runner.run(specs, _simple_trial_fn)
+
+    assert batch.total_trials == 1
+    assert batch.successful_trials == 1
+    assert batch.success_rate == 1.0
+
+    # Verify result was persisted
+    result_path = store.get_trial_dir("v1", 1) / "result.json"
+    assert result_path.exists()
+    with result_path.open() as f:
+        data = json.load(f)
+    assert data["success"] is True
+
+
+def test_parallel_runner_multiple_trials(tmp_path: Path):
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=4,
+    )
+    specs = [TrialSpec(variant_name=f"v{i}", trial_id=i) for i in range(1, 9)]
+    batch = runner.run(specs, _simple_trial_fn)
+
+    assert batch.total_trials == 8
+    assert batch.successful_trials == 8
+
+
+def test_parallel_runner_isolation(tmp_path: Path):
+    """Each trial must get its own backend instance."""
+    backend_ids: list[int] = []
+    lock = threading.Lock()
+
+    def tracking_trial_fn(
+        backend: SimulatorBackend, output_dir: Path, spec: TrialSpec
+    ) -> TrialResult:
+        with lock:
+            backend_ids.append(id(backend))
+        backend.reset()
+        return TrialResult(trial_id=spec.trial_id, success=True)
+
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=4,
+    )
+    specs = [TrialSpec(variant_name="v1", trial_id=i) for i in range(1, 5)]
+    runner.run(specs, tracking_trial_fn)
+
+    # All backend instances should be unique objects
+    assert len(set(backend_ids)) == 4
+
+
+def test_parallel_runner_output_dirs_isolated(tmp_path: Path):
+    """Each trial must write to its own output directory."""
+    seen_dirs: list[Path] = []
+    lock = threading.Lock()
+
+    def dir_tracking_fn(
+        backend: SimulatorBackend, output_dir: Path, spec: TrialSpec
+    ) -> TrialResult:
+        with lock:
+            seen_dirs.append(output_dir)
+        return TrialResult(trial_id=spec.trial_id, success=True)
+
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=2,
+    )
+    specs = [
+        TrialSpec(variant_name="v1", trial_id=1),
+        TrialSpec(variant_name="v1", trial_id=2),
+        TrialSpec(variant_name="v2", trial_id=1),
+    ]
+    runner.run(specs, dir_tracking_fn)
+
+    assert len(set(seen_dirs)) == 3
+
+
+def test_parallel_runner_handles_trial_failure(tmp_path: Path):
+    """Runner should catch exceptions and record them as failed trials."""
+
+    def failing_trial_fn(
+        backend: SimulatorBackend, output_dir: Path, spec: TrialSpec
+    ) -> TrialResult:
+        if spec.trial_id == 2:
+            raise RuntimeError("Simulator crashed")
+        return TrialResult(trial_id=spec.trial_id, success=True)
+
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=2,
+    )
+    specs = [
+        TrialSpec(variant_name="v1", trial_id=1),
+        TrialSpec(variant_name="v1", trial_id=2),
+        TrialSpec(variant_name="v1", trial_id=3),
+    ]
+    batch = runner.run(specs, failing_trial_fn)
+
+    assert batch.total_trials == 3
+    assert batch.successful_trials == 2
+    assert batch.failed_trials == 1
+    # The failed trial should have reason containing the error
+    failed = [r for r in batch.results if not r.success]
+    assert len(failed) == 1
+    assert "Simulator crashed" in failed[0].reason
+
+
+def test_parallel_runner_preserves_order(tmp_path: Path):
+    """Results must correspond to specs by index."""
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=4,
+    )
+    specs = [TrialSpec(variant_name="v1", trial_id=i) for i in range(1, 6)]
+    batch = runner.run(specs, _simple_trial_fn)
+
+    for spec, result in zip(batch.specs, batch.results, strict=True):
+        assert spec.trial_id == result.trial_id
+
+
+def test_parallel_runner_with_harness(tmp_path: Path):
+    """Integration test: trial_fn creates a Harness and runs checkpoints."""
+
+    def harness_trial_fn(
+        backend: SimulatorBackend, output_dir: Path, spec: TrialSpec
+    ) -> TrialResult:
+        harness = Harness(backend=backend, output_dir=output_dir, task_name="run")
+        harness.add_checkpoint("phase_a", cameras=["front"])
+        harness.reset()
+        result = harness.run_to_next_checkpoint([np.zeros(3)] * 5)
+        reached = [result.checkpoint_name] if result else []
+        return TrialResult(
+            trial_id=spec.trial_id,
+            success=result is not None,
+            checkpoints_reached=reached,
+        )
+
+    store = TaskStore(tmp_path, "test_task")
+    runner = ParallelTrialRunner(
+        backend_factory=MockBackend,
+        store=store,
+        max_workers=2,
+    )
+    specs = [
+        TrialSpec(variant_name="v1", trial_id=1),
+        TrialSpec(variant_name="v1", trial_id=2),
+    ]
+    batch = runner.run(specs, harness_trial_fn)
+
+    assert batch.total_trials == 2
+    assert batch.successful_trials == 2
+    for result in batch.results:
+        assert result.checkpoints_reached == ["phase_a"]


### PR DESCRIPTION
Implements ParallelTrialRunner with isolated simulator instances per trial,
configurable concurrency via ThreadPoolExecutor, and BatchResult with
cross-trial aggregation (success rates, failure phase distribution,
per-variant summaries). Closes #49.

https://claude.ai/code/session_01V1eyDmwsRUja9cmLcPVmHq