### PR TITLE
feat: add component lifecycle metadata to track assumptions and expiration

### DIFF
--- a/docs/component-lifecycle-guide.md
+++ b/docs/component-lifecycle-guide.md
@@ -1,0 +1,121 @@
+# When to Remove a Harness Component
+
+Every harness component is a hypothesis about the current model's capability boundary. As models improve, these hypotheses expire at different rates. This guide defines the process for deciding when to retire a component.
+
+## Core idea
+
+Roboharness components exist because today's models have specific limitations — limited single-view 3D reasoning, noisy monocular depth, inability to diagnose failures without intermediate state, and self-rationalisation bias when evaluating their own output. Each of these limitations is temporary. The harness should get leaner over time, not accumulate indefinitely.
+
+## Lifecycle metadata
+
+Each component is annotated with structured lifecycle metadata (see `src/roboharness/core/lifecycle.py`):
+
+| Field | Purpose |
+|-------|---------|
+| `component_name` | Unique identifier |
+| `version_introduced` | When it was added |
+| `assumptions` | The capability-gap hypotheses it addresses |
+| `horizon` | Expected timeframe before assumptions expire |
+
+Each assumption records:
+- **description** — what limitation this assumes exists
+- **removal_condition** — the observable, testable condition under which the assumption no longer holds
+- **evidence** — notes from past experiments
+
+## Current component assumptions
+
+| Component | Assumed Limitation | Horizon | Removal Condition |
+|-----------|-------------------|---------|-------------------|
+| Multi-view capture | Single-view 3D inference is unreliable | Medium-term | >95% grasp success from single RGB view |
+| Depth capture | RGB-only depth estimation has gaps | Near-term | <1cm error from RGB at manipulation distances |
+| Intermediate checkpoints | Limited failure diagnosis from final state | Long-term | Reliable root-cause identification from final state only |
+| Constraint evaluator | Self-rationalisation bias | Very long-term | >90% concordance between self-eval and independent eval |
+
+## The "harness diet" review process
+
+Run this process when a new model generation is released or at quarterly intervals:
+
+### 1. Audit
+
+```python
+from roboharness import default_registry
+
+for report in default_registry.audit():
+    print(f"{report['component']} ({report['horizon']}): expired={report['expired']}")
+```
+
+### 2. Test removal conditions
+
+For each component, design a targeted experiment:
+
+1. **Baseline**: run the standard evaluation suite with the component enabled.
+2. **Ablation**: disable or bypass the component.
+3. **Compare**: measure task success rate, failure diagnosis quality, or evaluation concordance (depending on the component).
+
+Record results in the assumption's `evidence` field.
+
+### 3. Decide
+
+```python
+from roboharness import default_registry
+
+# Pass in experimental evidence
+evidence = {
+    "RGB-only depth estimation has gaps for close-range manipulation": True,
+    # ... other assumptions tested
+}
+reports = default_registry.audit(evidence=evidence)
+for r in reports:
+    if r["expired"]:
+        print(f"CANDIDATE FOR REMOVAL: {r['component']}")
+```
+
+A component is a candidate for removal when **all** of its assumptions are disproven by experimental evidence. Even then, removal should go through a deprecation cycle:
+
+1. Mark as deprecated in the next minor release.
+2. Log a warning when the component is used.
+3. Remove in the following minor release.
+
+### 4. Record
+
+After each review, update:
+- The assumption's `evidence` field with experiment results and date.
+- This guide's table if horizons or conditions change.
+- The changelog with any deprecations or removals.
+
+## Adding new components
+
+When adding a new harness component, register its lifecycle metadata:
+
+```python
+from roboharness import (
+    ComponentAssumption,
+    ComponentLifecycle,
+    ExpirationHorizon,
+    default_registry,
+)
+
+default_registry.register(
+    ComponentLifecycle(
+        component_name="my_new_component",
+        version_introduced="0.4.0",
+        assumptions=[
+            ComponentAssumption(
+                description="Models cannot do X reliably",
+                removal_condition="Model achieves Y on benchmark Z",
+            ),
+        ],
+        horizon=ExpirationHorizon.MEDIUM_TERM,
+    )
+)
+```
+
+If you cannot articulate the assumption and removal condition, reconsider whether the component is necessary.
+
+## Historical removals
+
+_No components have been removed yet. This section will track removal decisions and their outcomes._
+
+| Component | Removed in | Reason | Impact |
+|-----------|-----------|--------|--------|
+| — | — | — | — |

--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -6,6 +6,13 @@ from roboharness.core.capture import CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore
 from roboharness.core.controller import Controller
 from roboharness.core.harness import Harness
+from roboharness.core.lifecycle import (
+    ComponentAssumption,
+    ComponentLifecycle,
+    ExpirationHorizon,
+    LifecycleRegistry,
+    default_registry,
+)
 from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
 
 __all__ = [
@@ -13,8 +20,13 @@ __all__ = [
     "CaptureResult",
     "Checkpoint",
     "CheckpointStore",
+    "ComponentAssumption",
+    "ComponentLifecycle",
     "Controller",
+    "ExpirationHorizon",
     "Harness",
+    "LifecycleRegistry",
     "ParallelTrialRunner",
     "TrialSpec",
+    "default_registry",
 ]

--- a/src/roboharness/core/lifecycle.py
+++ b/src/roboharness/core/lifecycle.py
@@ -1,0 +1,248 @@
+"""Component lifecycle metadata: track harness assumptions and expiration.
+
+Every harness component encodes a hypothesis about the current model's
+capability boundary.  As models improve, components should be re-evaluated
+and potentially retired.  This module provides lightweight metadata to make
+those assumptions explicit and reviewable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class ExpirationHorizon(Enum):
+    """Expected timeframe before a component's underlying assumption expires."""
+
+    NEAR_TERM = "near_term"  # likely obsolete within 1 model generation
+    MEDIUM_TERM = "medium_term"  # 2-3 model generations
+    LONG_TERM = "long_term"  # 4+ model generations
+    VERY_LONG_TERM = "very_long_term"  # fundamental limitation, unlikely soon
+
+
+@dataclass(frozen=True)
+class ComponentAssumption:
+    """A single testable assumption that justifies a component's existence.
+
+    Attributes:
+        description: Human-readable statement of what limitation this assumes.
+        removal_condition: Observable condition under which this assumption
+            no longer holds and the component can be removed.
+        evidence: Optional notes on experiments or observations supporting
+            the assumption (or its expiration).
+    """
+
+    description: str
+    removal_condition: str
+    evidence: str = ""
+
+
+@dataclass
+class ComponentLifecycle:
+    """Lifecycle metadata for a harness component.
+
+    Attach this to any component that encodes an implicit model-capability
+    assumption.  The metadata makes it possible to conduct periodic
+    "harness diet" reviews when new models are released.
+
+    Attributes:
+        component_name: Unique identifier (e.g. ``"multi_view_capture"``).
+        version_introduced: Version string when the component was added.
+        assumptions: The capability-gap hypotheses this component addresses.
+        horizon: Expected timeframe before the assumptions expire.
+        metadata: Arbitrary extra annotations.
+    """
+
+    component_name: str
+    version_introduced: str
+    assumptions: list[ComponentAssumption] = field(default_factory=list)
+    horizon: ExpirationHorizon = ExpirationHorizon.LONG_TERM
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, evidence: dict[str, bool] | None = None) -> bool:
+        """Check whether all assumptions have been invalidated.
+
+        Args:
+            evidence: Mapping of assumption descriptions to ``True`` if the
+                assumption has been empirically disproven (i.e. removal
+                condition met).  Assumptions not present in the dict are
+                treated as still valid.
+
+        Returns:
+            ``True`` when *every* assumption is disproven, meaning the
+            component is a candidate for removal.
+        """
+        if not self.assumptions:
+            return False
+        if evidence is None:
+            return False
+        return all(evidence.get(a.description, False) for a in self.assumptions)
+
+    def summary(self) -> dict[str, Any]:
+        """Return a JSON-serialisable summary for reports and metadata files."""
+        return {
+            "component": self.component_name,
+            "version_introduced": self.version_introduced,
+            "horizon": self.horizon.value,
+            "assumptions": [
+                {
+                    "description": a.description,
+                    "removal_condition": a.removal_condition,
+                    "evidence": a.evidence,
+                }
+                for a in self.assumptions
+            ],
+            **self.metadata,
+        }
+
+
+class LifecycleRegistry:
+    """Central registry of component lifecycle metadata.
+
+    Typical usage::
+
+        registry = LifecycleRegistry()
+        registry.register(ComponentLifecycle(
+            component_name="depth_capture",
+            version_introduced="0.1.0",
+            assumptions=[ComponentAssumption(...)],
+            horizon=ExpirationHorizon.NEAR_TERM,
+        ))
+
+        # During a "harness diet" review:
+        for report in registry.audit():
+            print(report)
+    """
+
+    def __init__(self) -> None:
+        self._components: dict[str, ComponentLifecycle] = {}
+
+    def register(self, lifecycle: ComponentLifecycle) -> None:
+        """Register lifecycle metadata for a component."""
+        self._components[lifecycle.component_name] = lifecycle
+
+    def get(self, component_name: str) -> ComponentLifecycle | None:
+        """Look up lifecycle metadata by component name."""
+        return self._components.get(component_name)
+
+    def list_components(self) -> list[str]:
+        """Return all registered component names."""
+        return list(self._components.keys())
+
+    def audit(self, evidence: dict[str, bool] | None = None) -> list[dict[str, Any]]:
+        """Produce an audit report for all registered components.
+
+        Args:
+            evidence: Optional mapping of assumption descriptions to booleans.
+                See :meth:`ComponentLifecycle.is_expired`.
+
+        Returns:
+            List of summary dicts, each augmented with an ``"expired"`` flag.
+        """
+        reports: list[dict[str, Any]] = []
+        for lifecycle in self._components.values():
+            report = lifecycle.summary()
+            report["expired"] = lifecycle.is_expired(evidence)
+            reports.append(report)
+        return reports
+
+    def by_horizon(self, horizon: ExpirationHorizon) -> list[ComponentLifecycle]:
+        """Return components matching a given expiration horizon."""
+        return [c for c in self._components.values() if c.horizon == horizon]
+
+    def __len__(self) -> int:
+        return len(self._components)
+
+    def __contains__(self, component_name: str) -> bool:
+        return component_name in self._components
+
+
+# ---------------------------------------------------------------------------
+# Default registry with roboharness built-in component assumptions
+# ---------------------------------------------------------------------------
+
+
+def _build_default_registry() -> LifecycleRegistry:
+    """Create the default registry pre-populated with core component metadata."""
+    registry = LifecycleRegistry()
+
+    registry.register(
+        ComponentLifecycle(
+            component_name="multi_view_capture",
+            version_introduced="0.1.0",
+            assumptions=[
+                ComponentAssumption(
+                    description="Single-view 3D inference is unreliable for manipulation tasks",
+                    removal_condition=(
+                        "Model achieves >95% grasp success from a single RGB view "
+                        "without auxiliary camera angles"
+                    ),
+                ),
+            ],
+            horizon=ExpirationHorizon.MEDIUM_TERM,
+        )
+    )
+
+    registry.register(
+        ComponentLifecycle(
+            component_name="depth_capture",
+            version_introduced="0.1.0",
+            assumptions=[
+                ComponentAssumption(
+                    description="RGB-only depth estimation has gaps for close-range manipulation",
+                    removal_condition=(
+                        "Model infers metric depth from RGB alone with <1cm error "
+                        "at manipulation distances (<1m)"
+                    ),
+                ),
+            ],
+            horizon=ExpirationHorizon.NEAR_TERM,
+        )
+    )
+
+    registry.register(
+        ComponentLifecycle(
+            component_name="intermediate_checkpoints",
+            version_introduced="0.1.0",
+            assumptions=[
+                ComponentAssumption(
+                    description=(
+                        "Models have limited ability to diagnose failures from final state alone"
+                    ),
+                    removal_condition=(
+                        "Model reliably identifies failure root cause and recovery "
+                        "strategy from final-state observation only"
+                    ),
+                ),
+            ],
+            horizon=ExpirationHorizon.LONG_TERM,
+        )
+    )
+
+    registry.register(
+        ComponentLifecycle(
+            component_name="constraint_evaluator",
+            version_introduced="0.3.0",
+            assumptions=[
+                ComponentAssumption(
+                    description=(
+                        "Models exhibit self-rationalisation bias when evaluating own outputs"
+                    ),
+                    removal_condition=(
+                        "Model self-evaluation matches independent evaluator agreement "
+                        "rate (>90% concordance on pass/fail)"
+                    ),
+                ),
+            ],
+            horizon=ExpirationHorizon.VERY_LONG_TERM,
+        )
+    )
+
+    return registry
+
+
+default_registry: LifecycleRegistry = _build_default_registry()
+"""Pre-populated registry with lifecycle metadata for all core roboharness
+components.  Import and query this directly for audits and reports."""

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,251 @@
+"""Tests for component lifecycle metadata."""
+
+from __future__ import annotations
+
+import pytest
+
+from roboharness.core.lifecycle import (
+    ComponentAssumption,
+    ComponentLifecycle,
+    ExpirationHorizon,
+    LifecycleRegistry,
+    default_registry,
+)
+
+# ---------------------------------------------------------------------------
+# ComponentAssumption
+# ---------------------------------------------------------------------------
+
+
+def test_assumption_fields():
+    a = ComponentAssumption(
+        description="Models can't do X",
+        removal_condition="Model does X reliably",
+        evidence="Tested on v2, still fails",
+    )
+    assert a.description == "Models can't do X"
+    assert a.removal_condition == "Model does X reliably"
+    assert a.evidence == "Tested on v2, still fails"
+
+
+def test_assumption_default_evidence():
+    a = ComponentAssumption(description="d", removal_condition="r")
+    assert a.evidence == ""
+
+
+def test_assumption_is_frozen():
+    a = ComponentAssumption(description="d", removal_condition="r")
+    with pytest.raises(AttributeError):
+        a.description = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ComponentLifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_defaults():
+    lc = ComponentLifecycle(component_name="test", version_introduced="0.1.0")
+    assert lc.assumptions == []
+    assert lc.horizon == ExpirationHorizon.LONG_TERM
+    assert lc.metadata == {}
+
+
+def test_lifecycle_is_expired_no_assumptions():
+    lc = ComponentLifecycle(component_name="test", version_introduced="0.1.0")
+    assert lc.is_expired() is False
+    assert lc.is_expired({"anything": True}) is False
+
+
+def test_lifecycle_is_expired_no_evidence():
+    lc = ComponentLifecycle(
+        component_name="test",
+        version_introduced="0.1.0",
+        assumptions=[ComponentAssumption(description="A", removal_condition="R")],
+    )
+    assert lc.is_expired() is False
+    assert lc.is_expired({}) is False
+
+
+def test_lifecycle_is_expired_partial_evidence():
+    lc = ComponentLifecycle(
+        component_name="test",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(description="A1", removal_condition="R1"),
+            ComponentAssumption(description="A2", removal_condition="R2"),
+        ],
+    )
+    assert lc.is_expired({"A1": True}) is False
+
+
+def test_lifecycle_is_expired_all_disproven():
+    lc = ComponentLifecycle(
+        component_name="test",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(description="A1", removal_condition="R1"),
+            ComponentAssumption(description="A2", removal_condition="R2"),
+        ],
+    )
+    assert lc.is_expired({"A1": True, "A2": True}) is True
+
+
+def test_lifecycle_summary():
+    lc = ComponentLifecycle(
+        component_name="depth",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(
+                description="RGB depth is bad",
+                removal_condition="RGB depth is good",
+                evidence="tested v3",
+            ),
+        ],
+        horizon=ExpirationHorizon.NEAR_TERM,
+        metadata={"owner": "core-team"},
+    )
+    s = lc.summary()
+    assert s["component"] == "depth"
+    assert s["version_introduced"] == "0.1.0"
+    assert s["horizon"] == "near_term"
+    assert len(s["assumptions"]) == 1
+    assert s["assumptions"][0]["evidence"] == "tested v3"
+    assert s["owner"] == "core-team"
+
+
+# ---------------------------------------------------------------------------
+# LifecycleRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_and_get():
+    reg = LifecycleRegistry()
+    lc = ComponentLifecycle(component_name="c1", version_introduced="0.1.0")
+    reg.register(lc)
+    assert reg.get("c1") is lc
+    assert reg.get("missing") is None
+
+
+def test_registry_list_components():
+    reg = LifecycleRegistry()
+    reg.register(ComponentLifecycle(component_name="a", version_introduced="0.1.0"))
+    reg.register(ComponentLifecycle(component_name="b", version_introduced="0.1.0"))
+    assert sorted(reg.list_components()) == ["a", "b"]
+
+
+def test_registry_contains_and_len():
+    reg = LifecycleRegistry()
+    assert len(reg) == 0
+    assert "x" not in reg
+    reg.register(ComponentLifecycle(component_name="x", version_introduced="0.1.0"))
+    assert len(reg) == 1
+    assert "x" in reg
+
+
+def test_registry_by_horizon():
+    reg = LifecycleRegistry()
+    reg.register(
+        ComponentLifecycle(
+            component_name="a",
+            version_introduced="0.1.0",
+            horizon=ExpirationHorizon.NEAR_TERM,
+        )
+    )
+    reg.register(
+        ComponentLifecycle(
+            component_name="b",
+            version_introduced="0.1.0",
+            horizon=ExpirationHorizon.LONG_TERM,
+        )
+    )
+    near = reg.by_horizon(ExpirationHorizon.NEAR_TERM)
+    assert len(near) == 1
+    assert near[0].component_name == "a"
+
+
+def test_registry_audit():
+    reg = LifecycleRegistry()
+    reg.register(
+        ComponentLifecycle(
+            component_name="c",
+            version_introduced="0.1.0",
+            assumptions=[ComponentAssumption(description="A", removal_condition="R")],
+        )
+    )
+    reports = reg.audit()
+    assert len(reports) == 1
+    assert reports[0]["expired"] is False
+
+    reports = reg.audit(evidence={"A": True})
+    assert reports[0]["expired"] is True
+
+
+def test_registry_audit_empty():
+    reg = LifecycleRegistry()
+    assert reg.audit() == []
+
+
+# ---------------------------------------------------------------------------
+# Default registry (built-in component registrations)
+# ---------------------------------------------------------------------------
+
+
+def test_default_registry_has_four_components():
+    assert len(default_registry) == 4
+    expected = {
+        "multi_view_capture",
+        "depth_capture",
+        "intermediate_checkpoints",
+        "constraint_evaluator",
+    }
+    assert set(default_registry.list_components()) == expected
+
+
+def test_default_registry_horizons():
+    assert (
+        default_registry.get("depth_capture").horizon  # type: ignore[union-attr]
+        == ExpirationHorizon.NEAR_TERM
+    )
+    assert (
+        default_registry.get("multi_view_capture").horizon  # type: ignore[union-attr]
+        == ExpirationHorizon.MEDIUM_TERM
+    )
+    assert (
+        default_registry.get("intermediate_checkpoints").horizon  # type: ignore[union-attr]
+        == ExpirationHorizon.LONG_TERM
+    )
+    assert (
+        default_registry.get("constraint_evaluator").horizon  # type: ignore[union-attr]
+        == ExpirationHorizon.VERY_LONG_TERM
+    )
+
+
+def test_default_registry_none_expired_without_evidence():
+    reports = default_registry.audit()
+    assert all(r["expired"] is False for r in reports)
+
+
+def test_default_registry_each_has_assumptions():
+    for name in default_registry.list_components():
+        lc = default_registry.get(name)
+        assert lc is not None
+        assert len(lc.assumptions) >= 1
+        for a in lc.assumptions:
+            assert a.description
+            assert a.removal_condition
+
+
+def test_public_api_exports():
+    """Lifecycle types are importable from the top-level package."""
+    from roboharness import ComponentAssumption as CA
+    from roboharness import ComponentLifecycle as CL
+    from roboharness import ExpirationHorizon as EH
+    from roboharness import LifecycleRegistry as LR
+    from roboharness import default_registry as dr
+
+    assert CA is ComponentAssumption
+    assert CL is ComponentLifecycle
+    assert EH is ExpirationHorizon
+    assert LR is LifecycleRegistry
+    assert dr is default_registry


### PR DESCRIPTION
Components encode implicit assumptions about model capability boundaries.
This adds a metadata layer (ComponentAssumption, ComponentLifecycle,
LifecycleRegistry) so those assumptions are explicit and auditable,
enabling periodic "harness diet" reviews when new models release.

- Register all four core components with their assumptions and horizons
- Export lifecycle types from the public API
- Add 20 tests covering all lifecycle metadata functionality
- Add component lifecycle guide with removal process documentation

Closes #50

https://claude.ai/code/session_0189kBvfukWoR6kyXPQZJWpX