### PR TITLE
feat: add evaluation history store and trend detection

### DIFF
--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -14,6 +14,7 @@ from roboharness.core.lifecycle import (
     default_registry,
 )
 from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
+from roboharness.storage.history import EvaluationHistory, EvaluationRecord, TrendResult
 
 __all__ = [
     "BatchResult",
@@ -23,10 +24,13 @@ __all__ = [
     "ComponentAssumption",
     "ComponentLifecycle",
     "Controller",
+    "EvaluationHistory",
+    "EvaluationRecord",
     "ExpirationHorizon",
     "Harness",
     "LifecycleRegistry",
     "ParallelTrialRunner",
+    "TrendResult",
     "TrialSpec",
     "default_registry",
 ]

--- a/src/roboharness/cli.py
+++ b/src/roboharness/cli.py
@@ -18,6 +18,7 @@ from roboharness.evaluate.batch import (
 )
 from roboharness.evaluate.constraints import load_constraints
 from roboharness.evaluate.defaults import GRASP_DEFAULTS
+from roboharness.storage.history import EvaluationHistory, detect_trend
 
 
 def _find_metadata_files(output_dir: Path) -> list[Path]:
@@ -240,6 +241,31 @@ def evaluate_command(
     return result.to_dict(), exit_code
 
 
+def trend_command(
+    output_dir: Path, window: int = 5, threshold: float = 0.1
+) -> list[dict[str, Any]]:
+    """Show success rate trends by comparing current report against history.
+
+    Generates a report (if needed), records it in eval_history.jsonl, and
+    compares against recent runs.  Returns a list of trend result dicts.
+    """
+    report = report_command(output_dir)
+    history = EvaluationHistory(output_dir)
+
+    trends: list[dict[str, Any]] = []
+    for task_name, task_data in report.get("tasks", {}).items():
+        rate = task_data.get("success_rate")
+        if rate is None:
+            continue
+        result = detect_trend(history, task_name, rate, window=window, threshold=threshold)
+        trends.append(result.to_dict())
+
+    # Record current run *after* trend detection so it doesn't compare against itself
+    history.record_from_report(report)
+
+    return trends
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -268,6 +294,34 @@ def main(argv: list[str] | None = None) -> int:
         "output_dir",
         type=Path,
         help="Path to harness output directory.",
+    )
+    report_parser.add_argument(
+        "--trend",
+        action="store_true",
+        help="Show success rate trends vs. recent history.",
+    )
+
+    # trend
+    trend_parser = subparsers.add_parser(
+        "trend",
+        help="Show success rate trends across evaluation runs.",
+    )
+    trend_parser.add_argument(
+        "output_dir",
+        type=Path,
+        help="Path to harness output directory.",
+    )
+    trend_parser.add_argument(
+        "--window",
+        type=int,
+        default=5,
+        help="Number of recent runs to compare against (default: 5).",
+    )
+    trend_parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.1,
+        help="Minimum delta to flag as regression/improvement (default: 0.1).",
     )
 
     # evaluate
@@ -354,7 +408,39 @@ def main(argv: list[str] | None = None) -> int:
             rate = task_data.get("success_rate")
             rate_str = f"{rate:.0%}" if rate is not None else "N/A"
             print(f"  {task_name}: {total} trials, {captures} captures, success={rate_str}")
+
+        if args.trend:
+            trends = trend_command(args.output_dir)
+            if trends:
+                print("\nTrend analysis:")
+                for t in trends:
+                    print(f"  {t['message']}")
+            else:
+                print("\nNo trend data available (no tasks with results).")
         return 0
+
+    if args.command == "trend":
+        try:
+            trends = trend_command(
+                args.output_dir,
+                window=args.window,
+                threshold=args.threshold,
+            )
+        except FileNotFoundError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+        if not trends:
+            print("No trend data available (no tasks with results).")
+            return 0
+
+        has_regression = False
+        for t in trends:
+            print(t["message"])
+            if t["regressed"]:
+                has_regression = True
+
+        return 2 if has_regression else 0
 
     if args.command == "evaluate":
         try:

--- a/src/roboharness/storage/__init__.py
+++ b/src/roboharness/storage/__init__.py
@@ -1,5 +1,12 @@
 """Storage format for Roboharness capture data."""
 
+from roboharness.storage.history import EvaluationHistory, EvaluationRecord, TrendResult
 from roboharness.storage.task_store import GraspTaskStore, TaskStore
 
-__all__ = ["GraspTaskStore", "TaskStore"]
+__all__ = [
+    "EvaluationHistory",
+    "EvaluationRecord",
+    "GraspTaskStore",
+    "TaskStore",
+    "TrendResult",
+]

--- a/src/roboharness/storage/history.py
+++ b/src/roboharness/storage/history.py
@@ -1,0 +1,195 @@
+"""Evaluation history store for tracking success rates across runs.
+
+Append-only JSONL files persist evaluation results with timestamps, git commit
+hashes, task names, verdicts, and metrics.  Trend detection compares current
+runs against recent history to flag regressions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class EvaluationRecord:
+    """A single evaluation run persisted in the history store."""
+
+    task: str
+    success_rate: float
+    total_trials: int
+    successes: int
+    timestamp: float = field(default_factory=time.time)
+    commit: str = ""
+    metrics: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvaluationRecord:
+        return cls(
+            task=data["task"],
+            success_rate=data["success_rate"],
+            total_trials=data["total_trials"],
+            successes=data["successes"],
+            timestamp=data.get("timestamp", 0.0),
+            commit=data.get("commit", ""),
+            metrics=data.get("metrics", {}),
+        )
+
+
+@dataclass
+class TrendResult:
+    """Result of comparing current evaluation against recent history."""
+
+    task: str
+    current_rate: float
+    previous_rate: float | None
+    delta: float | None
+    window_size: int
+    regressed: bool
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _get_git_commit() -> str:
+    """Get the current git commit hash, or empty string if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+class EvaluationHistory:
+    """Append-only JSONL store for evaluation results.
+
+    Records are stored in ``eval_history.jsonl`` inside the given directory.
+    Each line is a JSON object representing one :class:`EvaluationRecord`.
+    """
+
+    FILENAME = "eval_history.jsonl"
+
+    def __init__(self, directory: Path | str) -> None:
+        self.directory = Path(directory)
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._path = self.directory / self.FILENAME
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, record: EvaluationRecord) -> None:
+        """Append a single evaluation record to the history file."""
+        with self._path.open("a") as f:
+            f.write(json.dumps(record.to_dict(), default=str) + "\n")
+
+    def load(self, task: str | None = None) -> list[EvaluationRecord]:
+        """Load all records, optionally filtered by task name."""
+        if not self._path.exists():
+            return []
+        records: list[EvaluationRecord] = []
+        with self._path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                data = json.loads(line)
+                if task is None or data.get("task") == task:
+                    records.append(EvaluationRecord.from_dict(data))
+        return records
+
+    def record_from_report(
+        self, report: dict[str, Any], commit: str = ""
+    ) -> list[EvaluationRecord]:
+        """Create and append records from a ``report_command`` report dict.
+
+        Returns the list of records that were appended.
+        """
+        if not commit:
+            commit = _get_git_commit()
+
+        records: list[EvaluationRecord] = []
+        for task_name, task_data in report.get("tasks", {}).items():
+            rate = task_data.get("success_rate")
+            if rate is None:
+                continue
+            record = EvaluationRecord(
+                task=task_name,
+                success_rate=rate,
+                total_trials=task_data.get("trials_with_results", 0),
+                successes=task_data.get("successes", 0),
+                commit=commit,
+                metrics={},
+            )
+            self.append(record)
+            records.append(record)
+        return records
+
+
+def detect_trend(
+    history: EvaluationHistory,
+    task: str,
+    current_rate: float,
+    window: int = 5,
+    threshold: float = 0.1,
+) -> TrendResult:
+    """Compare *current_rate* against the last *window* runs for *task*.
+
+    A regression is flagged when the current rate is more than *threshold*
+    below the average of recent history.
+    """
+    records = history.load(task=task)
+
+    if not records:
+        return TrendResult(
+            task=task,
+            current_rate=current_rate,
+            previous_rate=None,
+            delta=None,
+            window_size=0,
+            regressed=False,
+            message=f"No previous history for '{task}' — baseline recorded.",
+        )
+
+    recent = records[-window:]
+    avg_rate = sum(r.success_rate for r in recent) / len(recent)
+    delta = current_rate - avg_rate
+    regressed = delta < -threshold
+
+    if regressed:
+        msg = (
+            f"REGRESSION: '{task}' success rate dropped from "
+            f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
+        )
+    elif delta > threshold:
+        msg = (
+            f"IMPROVEMENT: '{task}' success rate rose from "
+            f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
+        )
+    else:
+        msg = f"'{task}' success rate stable at {current_rate:.0%} (avg {avg_rate:.0%})"
+
+    return TrendResult(
+        task=task,
+        current_rate=current_rate,
+        previous_rate=avg_rate,
+        delta=delta,
+        window_size=len(recent),
+        regressed=regressed,
+        message=msg,
+    )

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,291 @@
+"""Tests for evaluation history store and trend detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from roboharness.cli import main, trend_command
+from roboharness.storage.history import (
+    EvaluationHistory,
+    EvaluationRecord,
+    TrendResult,
+    detect_trend,
+)
+
+
+class TestEvaluationRecord:
+    def test_round_trip(self) -> None:
+        record = EvaluationRecord(
+            task="grasp",
+            success_rate=0.8,
+            total_trials=10,
+            successes=8,
+            timestamp=1000.0,
+            commit="abc123",
+            metrics={"lift_height": 0.15},
+        )
+        data = record.to_dict()
+        restored = EvaluationRecord.from_dict(data)
+        assert restored.task == "grasp"
+        assert restored.success_rate == 0.8
+        assert restored.commit == "abc123"
+        assert restored.metrics == {"lift_height": 0.15}
+
+    def test_from_dict_defaults(self) -> None:
+        record = EvaluationRecord.from_dict(
+            {"task": "t", "success_rate": 0.5, "total_trials": 2, "successes": 1}
+        )
+        assert record.timestamp == 0.0
+        assert record.commit == ""
+        assert record.metrics == {}
+
+
+class TestEvaluationHistory:
+    def test_append_and_load(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        record = EvaluationRecord(task="grasp", success_rate=0.9, total_trials=10, successes=9)
+        history.append(record)
+        loaded = history.load()
+        assert len(loaded) == 1
+        assert loaded[0].task == "grasp"
+        assert loaded[0].success_rate == 0.9
+
+    def test_append_is_additive(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        for i in range(3):
+            history.append(
+                EvaluationRecord(
+                    task="grasp", success_rate=0.5 + i * 0.1, total_trials=10, successes=5 + i
+                )
+            )
+        assert len(history.load()) == 3
+
+    def test_load_filter_by_task(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        history.append(
+            EvaluationRecord(task="grasp", success_rate=0.9, total_trials=10, successes=9)
+        )
+        history.append(
+            EvaluationRecord(task="push", success_rate=0.5, total_trials=10, successes=5)
+        )
+        assert len(history.load(task="grasp")) == 1
+        assert len(history.load(task="push")) == 1
+        assert len(history.load()) == 2
+
+    def test_load_empty(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        assert history.load() == []
+
+    def test_jsonl_format(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        history.append(EvaluationRecord(task="t", success_rate=0.5, total_trials=2, successes=1))
+        lines = history.path.read_text().strip().split("\n")
+        assert len(lines) == 1
+        data = json.loads(lines[0])
+        assert data["task"] == "t"
+
+    def test_record_from_report(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        report = {
+            "tasks": {
+                "grasp": {
+                    "success_rate": 0.75,
+                    "trials_with_results": 4,
+                    "successes": 3,
+                },
+                "push": {
+                    "success_rate": None,  # no results — should be skipped
+                    "trials_with_results": 0,
+                    "successes": 0,
+                },
+            }
+        }
+        records = history.record_from_report(report, commit="abc123")
+        assert len(records) == 1
+        assert records[0].task == "grasp"
+        assert records[0].commit == "abc123"
+        loaded = history.load()
+        assert len(loaded) == 1
+
+
+class TestDetectTrend:
+    def _make_history(self, tmp_path: Path, rates: list[float]) -> EvaluationHistory:
+        history = EvaluationHistory(tmp_path)
+        for i, rate in enumerate(rates):
+            history.append(
+                EvaluationRecord(
+                    task="grasp",
+                    success_rate=rate,
+                    total_trials=10,
+                    successes=int(rate * 10),
+                    timestamp=float(1000 + i),
+                )
+            )
+        return history
+
+    def test_no_history(self, tmp_path: Path) -> None:
+        history = EvaluationHistory(tmp_path)
+        result = detect_trend(history, "grasp", 0.8)
+        assert not result.regressed
+        assert result.previous_rate is None
+        assert "baseline" in result.message.lower()
+
+    def test_stable(self, tmp_path: Path) -> None:
+        history = self._make_history(tmp_path, [0.8, 0.8, 0.8])
+        result = detect_trend(history, "grasp", 0.8)
+        assert not result.regressed
+        assert "stable" in result.message.lower()
+
+    def test_regression(self, tmp_path: Path) -> None:
+        history = self._make_history(tmp_path, [0.9, 0.9, 0.9])
+        result = detect_trend(history, "grasp", 0.6)
+        assert result.regressed
+        assert result.delta is not None
+        assert result.delta < 0
+        assert "regression" in result.message.lower()
+        assert "90%" in result.message
+        assert "60%" in result.message
+
+    def test_improvement(self, tmp_path: Path) -> None:
+        history = self._make_history(tmp_path, [0.5, 0.5, 0.5])
+        result = detect_trend(history, "grasp", 0.8)
+        assert not result.regressed
+        assert "improvement" in result.message.lower()
+
+    def test_window_limits(self, tmp_path: Path) -> None:
+        # 10 records but window=3 — only last 3 count
+        history = self._make_history(tmp_path, [0.2] * 7 + [0.9, 0.9, 0.9])
+        result = detect_trend(history, "grasp", 0.9, window=3)
+        assert not result.regressed
+        assert result.window_size == 3
+
+    def test_custom_threshold(self, tmp_path: Path) -> None:
+        history = self._make_history(tmp_path, [0.8, 0.8, 0.8])
+        # Delta of -0.15 is below default 0.1 threshold → regression
+        result = detect_trend(history, "grasp", 0.65, threshold=0.2)
+        assert not result.regressed  # delta=-0.15 > -0.2, so NOT regressed
+        result2 = detect_trend(history, "grasp", 0.65, threshold=0.1)
+        assert result2.regressed  # delta=-0.15 < -0.1, so regressed
+
+    def test_trend_result_to_dict(self) -> None:
+        tr = TrendResult(
+            task="t",
+            current_rate=0.5,
+            previous_rate=0.8,
+            delta=-0.3,
+            window_size=3,
+            regressed=True,
+            message="bad",
+        )
+        d = tr.to_dict()
+        assert d["regressed"] is True
+        assert d["delta"] == -0.3
+
+
+@pytest.fixture
+def harness_output_with_results(tmp_path: Path) -> Path:
+    """Minimal harness output with results for trend testing."""
+    trial_dir = tmp_path / "pick_and_place" / "trial_001"
+    cp = trial_dir / "pre_grasp"
+    cp.mkdir(parents=True)
+    (cp / "metadata.json").write_text(
+        json.dumps({"checkpoint": "pre_grasp", "step": 50, "sim_time": 0.5})
+    )
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_id": 1,
+                "success": True,
+                "reason": "ok",
+                "metrics": {},
+                "duration": 1.0,
+                "checkpoints_reached": ["pre_grasp"],
+                "timestamp": 1000000.0,
+            }
+        )
+    )
+    return tmp_path
+
+
+class TestTrendCommand:
+    def test_trend_first_run(self, harness_output_with_results: Path) -> None:
+        trends = trend_command(harness_output_with_results)
+        assert len(trends) == 1
+        assert trends[0]["task"] == "pick_and_place"
+        assert "baseline" in trends[0]["message"].lower()
+        # Should have written history
+        history = EvaluationHistory(harness_output_with_results)
+        assert len(history.load()) == 1
+
+    def test_trend_second_run_stable(self, harness_output_with_results: Path) -> None:
+        # First run records baseline
+        trend_command(harness_output_with_results)
+        # Second run should compare against first
+        trends = trend_command(harness_output_with_results)
+        assert len(trends) == 1
+        assert not trends[0]["regressed"]
+
+    def test_trend_cli_subcommand(
+        self,
+        harness_output_with_results: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ret = main(["trend", str(harness_output_with_results)])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "pick_and_place" in captured.out
+
+    def test_trend_cli_report_flag(
+        self,
+        harness_output_with_results: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        ret = main(["report", "--trend", str(harness_output_with_results)])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "Trend analysis" in captured.out
+
+    def test_trend_regression_exit_code(self, tmp_path: Path) -> None:
+        """Trend subcommand returns exit code 2 on regression."""
+        # Build history with high success rate
+        history = EvaluationHistory(tmp_path)
+        for _ in range(3):
+            history.append(
+                EvaluationRecord(
+                    task="pick_and_place",
+                    success_rate=0.9,
+                    total_trials=10,
+                    successes=9,
+                )
+            )
+
+        # Create current run with low success rate
+        trial_dir = tmp_path / "pick_and_place" / "trial_001"
+        cp = trial_dir / "pre_grasp"
+        cp.mkdir(parents=True)
+        (cp / "metadata.json").write_text(
+            json.dumps({"checkpoint": "pre_grasp", "step": 1, "sim_time": 0.1})
+        )
+        (trial_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "trial_id": 1,
+                    "success": False,
+                    "reason": "failed",
+                    "metrics": {},
+                    "duration": 0.1,
+                    "checkpoints_reached": ["pre_grasp"],
+                    "timestamp": 2000000.0,
+                }
+            )
+        )
+
+        ret = main(["trend", str(tmp_path)])
+        assert ret == 2
+
+    def test_trend_missing_dir(self, tmp_path: Path) -> None:
+        ret = main(["trend", str(tmp_path / "nope")])
+        assert ret == 1


### PR DESCRIPTION
Implement success rate trend tracking to detect regressions across commits:

- EvaluationHistory: append-only JSONL store for evaluation results with
  timestamps, git commit hashes, task names, verdicts, and metrics
- detect_trend(): compares current success rate against recent history
  (configurable window and threshold) and flags regressions
- CLI: `roboharness trend <dir>` subcommand and `--trend` flag on
  `roboharness report` for inline trend analysis
- Exit code 2 from trend subcommand signals regression (CI-friendly)

Closes #52

https://claude.ai/code/session_01THX7XpwFqeLKkWEZnFRLCX