### PR TITLE
docs: fix architecture diagram arrows and add new features

### DIFF
--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 420" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 460" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
   <defs>
     <linearGradient id="agentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
@@ -22,99 +22,98 @@
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto-start-reverse">
       <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
     </marker>
-    <marker id="arrowDown" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
-      <polygon points="0 0, 7 0, 3.5 10" fill="#64748b"/>
-    </marker>
-    <marker id="arrowDownLight" markerWidth="7" markerHeight="10" refX="3.5" refY="9" orient="auto">
-      <polygon points="0 0, 7 0, 3.5 10" fill="rgba(255,255,255,0.7)"/>
+    <marker id="arrowLight" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="rgba(255,255,255,0.7)"/>
     </marker>
   </defs>
 
   <!-- Background -->
-  <rect width="900" height="420" rx="16" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
+  <rect width="900" height="460" rx="16" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"/>
 
   <!-- Title -->
   <text x="450" y="38" text-anchor="middle" font-size="18" font-weight="700" fill="#1e293b">Roboharness: Visual Feedback Loop</text>
 
   <!-- Agent Box -->
-  <rect x="30" y="70" width="200" height="280" rx="12" fill="url(#agentGrad)" filter="url(#shadow)" opacity="0.95"/>
+  <rect x="30" y="70" width="200" height="260" rx="12" fill="url(#agentGrad)" filter="url(#shadow)" opacity="0.95"/>
   <text x="130" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="white">AI Coding Agent</text>
   <line x1="55" y1="112" x2="205" y2="112" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
   <text x="130" y="138" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Claude Code</text>
   <text x="130" y="158" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">OpenAI Codex</text>
-  <text x="130" y="178" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">OpenClaw</text>
-  <text x="130" y="198" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Any multimodal agent</text>
-  <line x1="55" y1="215" x2="205" y2="215" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
-  <text x="130" y="242" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">1. Writes control code</text>
-  <text x="130" y="264" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">2. Observes screenshots</text>
-  <text x="130" y="286" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">3. Judges success/failure</text>
-  <text x="130" y="308" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">4. Iterates until done</text>
+  <text x="130" y="178" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Any multimodal agent</text>
+  <line x1="55" y1="195" x2="205" y2="195" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
+  <text x="130" y="220" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">1. Write control code</text>
+  <text x="130" y="242" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">2. See screenshots</text>
+  <text x="130" y="264" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">3. Read evaluations</text>
+  <text x="130" y="286" text-anchor="middle" font-size="11" fill="rgba(255,255,255,0.85)">4. Iterate until done</text>
 
   <!-- Harness Box -->
-  <rect x="310" y="70" width="260" height="280" rx="12" fill="url(#harnessGrad)" filter="url(#shadow)" opacity="0.95"/>
+  <rect x="310" y="70" width="260" height="260" rx="12" fill="url(#harnessGrad)" filter="url(#shadow)" opacity="0.95"/>
   <text x="440" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="white">Roboharness</text>
   <line x1="335" y1="112" x2="545" y2="112" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
 
   <!-- Inner steps -->
-  <rect x="330" y="125" width="220" height="38" rx="8" fill="rgba(255,255,255,0.2)"/>
-  <text x="440" y="149" text-anchor="middle" font-size="12" font-weight="600" fill="white">Run Simulation</text>
+  <rect x="330" y="122" width="220" height="34" rx="8" fill="rgba(255,255,255,0.2)"/>
+  <text x="440" y="144" text-anchor="middle" font-size="12" font-weight="600" fill="white">Run Simulation (batch parallel)</text>
 
-  <rect x="330" y="175" width="220" height="38" rx="8" fill="rgba(255,255,255,0.2)"/>
-  <text x="440" y="199" text-anchor="middle" font-size="12" font-weight="600" fill="white">Pause at Checkpoints</text>
+  <!-- Down arrow 1 -->
+  <line x1="440" y1="156" x2="440" y2="168" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowLight)"/>
 
-  <rect x="330" y="225" width="220" height="38" rx="8" fill="rgba(255,255,255,0.2)"/>
-  <text x="440" y="249" text-anchor="middle" font-size="12" font-weight="600" fill="white">Capture Multi-View Screenshots</text>
+  <rect x="330" y="170" width="220" height="34" rx="8" fill="rgba(255,255,255,0.2)"/>
+  <text x="440" y="192" text-anchor="middle" font-size="12" font-weight="600" fill="white">Checkpoint &amp; Capture Views</text>
 
-  <rect x="330" y="275" width="220" height="38" rx="8" fill="rgba(255,255,255,0.2)"/>
-  <text x="440" y="299" text-anchor="middle" font-size="12" font-weight="600" fill="white">Return State + Images</text>
+  <!-- Down arrow 2 -->
+  <line x1="440" y1="204" x2="440" y2="216" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowLight)"/>
 
-  <!-- Small arrows between inner steps -->
-  <line x1="440" y1="163" x2="440" y2="175" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowDownLight)"/>
-  <line x1="440" y1="213" x2="440" y2="225" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowDownLight)"/>
-  <line x1="440" y1="263" x2="440" y2="275" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowDownLight)"/>
+  <rect x="330" y="218" width="220" height="34" rx="8" fill="rgba(255,255,255,0.2)"/>
+  <text x="440" y="240" text-anchor="middle" font-size="12" font-weight="600" fill="white">Evaluate (pass / fail)</text>
+
+  <!-- Down arrow 3 -->
+  <line x1="440" y1="252" x2="440" y2="264" stroke="rgba(255,255,255,0.5)" stroke-width="1.5" marker-end="url(#arrowLight)"/>
+
+  <rect x="330" y="266" width="220" height="34" rx="8" fill="rgba(255,255,255,0.2)"/>
+  <text x="440" y="288" text-anchor="middle" font-size="12" font-weight="600" fill="white">Return State + Images</text>
 
   <!-- Simulator Box -->
-  <rect x="650" y="70" width="220" height="155" rx="12" fill="url(#simGrad)" filter="url(#shadow)" opacity="0.95"/>
+  <rect x="650" y="70" width="220" height="140" rx="12" fill="url(#simGrad)" filter="url(#shadow)" opacity="0.95"/>
   <text x="760" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="white">Simulators</text>
   <line x1="675" y1="112" x2="845" y2="112" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
-  <text x="760" y="137" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">MuJoCo + Meshcat</text>
-  <text x="760" y="157" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Isaac Lab</text>
-  <text x="760" y="177" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">ManiSkill</text>
-  <text x="760" y="197" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Any Gymnasium env</text>
+  <text x="760" y="135" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">MuJoCo + Meshcat</text>
+  <text x="760" y="155" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Isaac Lab / ManiSkill</text>
+  <text x="760" y="175" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Any Gymnasium env</text>
 
   <!-- Output Box -->
-  <rect x="650" y="250" width="220" height="100" rx="12" fill="url(#outputGrad)" filter="url(#shadow)" opacity="0.95"/>
-  <text x="760" y="280" text-anchor="middle" font-size="15" font-weight="700" fill="white">Output</text>
-  <line x1="675" y1="292" x2="845" y2="292" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
-  <text x="760" y="315" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">PNG screenshots + JSON state</text>
-  <text x="760" y="335" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">HTML visual reports</text>
+  <rect x="650" y="235" width="220" height="95" rx="12" fill="url(#outputGrad)" filter="url(#shadow)" opacity="0.95"/>
+  <text x="760" y="265" text-anchor="middle" font-size="15" font-weight="700" fill="white">Output</text>
+  <line x1="675" y1="277" x2="845" y2="277" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>
+  <text x="760" y="298" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">Screenshots + JSON state</text>
+  <text x="760" y="318" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.9)">HTML reports + Verdicts</text>
 
   <!-- Arrows: Agent -> Harness -->
-  <line x1="230" y1="170" x2="310" y2="170" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="270" y="162" text-anchor="middle" font-size="10" fill="#64748b">code</text>
+  <line x1="230" y1="160" x2="310" y2="160" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="152" text-anchor="middle" font-size="10" fill="#64748b">code</text>
 
   <!-- Arrows: Harness -> Agent (feedback) -->
-  <line x1="310" y1="260" x2="230" y2="260" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="270" y="252" text-anchor="middle" font-size="10" fill="#64748b">images</text>
+  <line x1="310" y1="250" x2="230" y2="250" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="270" y="242" text-anchor="middle" font-size="10" fill="#64748b">images</text>
 
   <!-- Arrows: Harness -> Simulator -->
-  <line x1="570" y1="148" x2="650" y2="148" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="610" y="140" text-anchor="middle" font-size="10" fill="#64748b">actions</text>
+  <line x1="570" y1="140" x2="650" y2="140" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="610" y="132" text-anchor="middle" font-size="10" fill="#64748b">actions</text>
 
   <!-- Arrows: Simulator -> Harness -->
-  <line x1="650" y1="185" x2="570" y2="185" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
-  <text x="610" y="200" text-anchor="middle" font-size="10" fill="#64748b">frames</text>
+  <line x1="650" y1="175" x2="570" y2="175" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
+  <text x="610" y="192" text-anchor="middle" font-size="10" fill="#64748b">frames</text>
 
   <!-- Arrows: Harness -> Output -->
-  <line x1="570" y1="295" x2="650" y2="295" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="570" y1="280" x2="650" y2="280" stroke="#64748b" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- Loop arrow label -->
-  <rect x="100" y="370" width="280" height="32" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
-  <text x="240" y="391" text-anchor="middle" font-size="12" font-weight="600" fill="#475569">Loop until task succeeds</text>
+  <!-- Loop arrow label - moved down for more spacing -->
+  <rect x="100" y="400" width="280" height="32" rx="8" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+  <text x="240" y="421" text-anchor="middle" font-size="12" font-weight="600" fill="#475569">Loop until task succeeds</text>
 
   <!-- Curved loop arrow from bottom of agent back to top -->
-  <path d="M 130 350 L 130 390 L 20 390 L 20 120 L 30 120" fill="none" stroke="#64748b" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arrow)"/>
+  <path d="M 130 330 L 130 416 L 20 416 L 20 120 L 30 120" fill="none" stroke="#64748b" stroke-width="1.5" stroke-dasharray="6,3" marker-end="url(#arrow)"/>
 
   <!-- Footer -->
-  <text x="450" y="410" text-anchor="middle" font-size="11" fill="#94a3b8">Gymnasium Wrapper (1-line integration) | Core Harness API (full control) | SimulatorBackend protocol (custom)</text>
+  <text x="450" y="450" text-anchor="middle" font-size="11" fill="#94a3b8">Gymnasium Wrapper (1-line integration) | Core Harness API (full control) | SimulatorBackend protocol (custom)</text>
 </svg>


### PR DESCRIPTION
- Fix inner arrows in Roboharness box pointing left instead of down
  (replaced broken arrowDownLight marker with arrowLight using correct
  orient="auto-start-reverse" and right-pointing polygon shape)
- Add Evaluator step (pass/fail assertions) and batch parallel run
- Update Output box to include Verdicts
- Update agent workflow to include "Read evaluations" step
- Simplify agent list (removed OpenClaw, consolidated simulator list)
- Add more vertical spacing between loop label and content above

https://claude.ai/code/session_018NPD2MrM7hu6eMx65LGjZY