### PR TITLE
refactor: clean up evaluate, lifecycle, CLI, and runner modules

### DIFF
--- a/src/roboharness/cli.py
+++ b/src/roboharness/cli.py
@@ -21,19 +21,9 @@ from roboharness.evaluate.defaults import GRASP_DEFAULTS
 from roboharness.storage.history import EvaluationHistory, detect_trend
 
 
-def _find_metadata_files(output_dir: Path) -> list[Path]:
-    """Find all metadata.json files under the output directory."""
-    return sorted(output_dir.rglob("metadata.json"))
-
-
-def _find_result_files(output_dir: Path) -> list[Path]:
-    """Find all result.json files under the output directory."""
-    return sorted(output_dir.rglob("result.json"))
-
-
-def _find_image_files(directory: Path) -> list[Path]:
-    """Find all image files (PNG) in a directory."""
-    return sorted(directory.glob("*_rgb.png"))
+def _find_files(directory: Path, pattern: str, recursive: bool = True) -> list[Path]:
+    """Find files matching a glob pattern under a directory."""
+    return sorted(directory.rglob(pattern) if recursive else directory.glob(pattern))
 
 
 def _load_json(path: Path) -> Any:
@@ -65,7 +55,7 @@ def inspect_command(output_dir: Path) -> str:
     if not output_dir.exists():
         return f"Error: directory not found: {output_dir}"
 
-    metadata_files = _find_metadata_files(output_dir)
+    metadata_files = _find_files(output_dir, "metadata.json")
     if not metadata_files:
         return f"No captures found in {output_dir}"
 
@@ -108,7 +98,7 @@ def inspect_command(output_dir: Path) -> str:
         lines.append(f"    {checkpoint_name}  (step={step}, t={sim_time_str})")
 
         # List images
-        images = _find_image_files(checkpoint_dir)
+        images = _find_files(checkpoint_dir, "*_rgb.png", recursive=False)
         if images:
             img_names = [img.name for img in images]
             lines.append(f"      images: {', '.join(img_names)}")
@@ -134,8 +124,8 @@ def report_command(output_dir: Path) -> dict[str, Any]:
     if not output_dir.exists():
         raise FileNotFoundError(f"directory not found: {output_dir}")
 
-    result_files = _find_result_files(output_dir)
-    metadata_files = _find_metadata_files(output_dir)
+    result_files = _find_files(output_dir, "result.json")
+    metadata_files = _find_files(output_dir, "metadata.json")
 
     # Collect per-task info
     tasks: dict[str, dict[str, Any]] = {}
@@ -295,11 +285,6 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Path to harness output directory.",
     )
-    report_parser.add_argument(
-        "--trend",
-        action="store_true",
-        help="Show success rate trends vs. recent history.",
-    )
 
     # trend
     trend_parser = subparsers.add_parser(
@@ -408,15 +393,6 @@ def main(argv: list[str] | None = None) -> int:
             rate = task_data.get("success_rate")
             rate_str = f"{rate:.0%}" if rate is not None else "N/A"
             print(f"  {task_name}: {total} trials, {captures} captures, success={rate_str}")
-
-        if args.trend:
-            trends = trend_command(args.output_dir)
-            if trends:
-                print("\nTrend analysis:")
-                for t in trends:
-                    print(f"  {t['message']}")
-            else:
-                print("\nNo trend data available (no tasks with results).")
         return 0
 
     if args.command == "trend":

--- a/src/roboharness/core/lifecycle.py
+++ b/src/roboharness/core/lifecycle.py
@@ -74,15 +74,13 @@ class ComponentLifecycle:
             ``True`` when *every* assumption is disproven, meaning the
             component is a candidate for removal.
         """
-        if not self.assumptions:
-            return False
-        if evidence is None:
+        if not self.assumptions or evidence is None:
             return False
         return all(evidence.get(a.description, False) for a in self.assumptions)
 
     def summary(self) -> dict[str, Any]:
         """Return a JSON-serialisable summary for reports and metadata files."""
-        return {
+        result: dict[str, Any] = {
             "component": self.component_name,
             "version_introduced": self.version_introduced,
             "horizon": self.horizon.value,
@@ -94,8 +92,10 @@ class ComponentLifecycle:
                 }
                 for a in self.assumptions
             ],
-            **self.metadata,
         }
+        if self.metadata:
+            result["metadata"] = self.metadata
+        return result
 
 
 class LifecycleRegistry:
@@ -163,86 +163,78 @@ class LifecycleRegistry:
 # Default registry with roboharness built-in component assumptions
 # ---------------------------------------------------------------------------
 
-
-def _build_default_registry() -> LifecycleRegistry:
-    """Create the default registry pre-populated with core component metadata."""
-    registry = LifecycleRegistry()
-
-    registry.register(
-        ComponentLifecycle(
-            component_name="multi_view_capture",
-            version_introduced="0.1.0",
-            assumptions=[
-                ComponentAssumption(
-                    description="Single-view 3D inference is unreliable for manipulation tasks",
-                    removal_condition=(
-                        "Model achieves >95% grasp success from a single RGB view "
-                        "without auxiliary camera angles"
-                    ),
-                ),
-            ],
-            horizon=ExpirationHorizon.MEDIUM_TERM,
-        )
-    )
-
-    registry.register(
-        ComponentLifecycle(
-            component_name="depth_capture",
-            version_introduced="0.1.0",
-            assumptions=[
-                ComponentAssumption(
-                    description="RGB-only depth estimation has gaps for close-range manipulation",
-                    removal_condition=(
-                        "Model infers metric depth from RGB alone with <1cm error "
-                        "at manipulation distances (<1m)"
-                    ),
-                ),
-            ],
-            horizon=ExpirationHorizon.NEAR_TERM,
-        )
-    )
-
-    registry.register(
-        ComponentLifecycle(
-            component_name="intermediate_checkpoints",
-            version_introduced="0.1.0",
-            assumptions=[
-                ComponentAssumption(
-                    description=(
-                        "Models have limited ability to diagnose failures from final state alone"
-                    ),
-                    removal_condition=(
-                        "Model reliably identifies failure root cause and recovery "
-                        "strategy from final-state observation only"
-                    ),
-                ),
-            ],
-            horizon=ExpirationHorizon.LONG_TERM,
-        )
-    )
-
-    registry.register(
-        ComponentLifecycle(
-            component_name="constraint_evaluator",
-            version_introduced="0.3.0",
-            assumptions=[
-                ComponentAssumption(
-                    description=(
-                        "Models exhibit self-rationalisation bias when evaluating own outputs"
-                    ),
-                    removal_condition=(
-                        "Model self-evaluation matches independent evaluator agreement "
-                        "rate (>90% concordance on pass/fail)"
-                    ),
-                ),
-            ],
-            horizon=ExpirationHorizon.VERY_LONG_TERM,
-        )
-    )
-
-    return registry
-
-
-default_registry: LifecycleRegistry = _build_default_registry()
+default_registry: LifecycleRegistry = LifecycleRegistry()
 """Pre-populated registry with lifecycle metadata for all core roboharness
 components.  Import and query this directly for audits and reports."""
+
+default_registry.register(
+    ComponentLifecycle(
+        component_name="multi_view_capture",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(
+                description="Single-view 3D inference is unreliable for manipulation tasks",
+                removal_condition=(
+                    "Model achieves >95% grasp success from a single RGB view "
+                    "without auxiliary camera angles"
+                ),
+            ),
+        ],
+        horizon=ExpirationHorizon.MEDIUM_TERM,
+    )
+)
+
+default_registry.register(
+    ComponentLifecycle(
+        component_name="depth_capture",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(
+                description="RGB-only depth estimation has gaps for close-range manipulation",
+                removal_condition=(
+                    "Model infers metric depth from RGB alone with <1cm error "
+                    "at manipulation distances (<1m)"
+                ),
+            ),
+        ],
+        horizon=ExpirationHorizon.NEAR_TERM,
+    )
+)
+
+default_registry.register(
+    ComponentLifecycle(
+        component_name="intermediate_checkpoints",
+        version_introduced="0.1.0",
+        assumptions=[
+            ComponentAssumption(
+                description=(
+                    "Models have limited ability to diagnose failures from final state alone"
+                ),
+                removal_condition=(
+                    "Model reliably identifies failure root cause and recovery "
+                    "strategy from final-state observation only"
+                ),
+            ),
+        ],
+        horizon=ExpirationHorizon.LONG_TERM,
+    )
+)
+
+default_registry.register(
+    ComponentLifecycle(
+        component_name="constraint_evaluator",
+        version_introduced="0.3.0",
+        assumptions=[
+            ComponentAssumption(
+                description=(
+                    "Models exhibit self-rationalisation bias when evaluating own outputs"
+                ),
+                removal_condition=(
+                    "Model self-evaluation matches independent evaluator agreement "
+                    "rate (>90% concordance on pass/fail)"
+                ),
+            ),
+        ],
+        horizon=ExpirationHorizon.VERY_LONG_TERM,
+    )
+)

--- a/src/roboharness/evaluate/__init__.py
+++ b/src/roboharness/evaluate/__init__.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion
 from roboharness.evaluate.batch import (
-    BatchResult,
     ComparisonResult,
+    EvalBatchResult,
     VariantResult,
     check_success_rate,
     evaluate_batch,
@@ -25,8 +25,8 @@ __all__ = [
     "GRASP_DEFAULTS",
     "AssertionEngine",
     "AssertionResult",
-    "BatchResult",
     "ComparisonResult",
+    "EvalBatchResult",
     "EvaluationResult",
     "MetricAssertion",
     "Operator",

--- a/src/roboharness/evaluate/assertions.py
+++ b/src/roboharness/evaluate/assertions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -111,20 +112,15 @@ def _extract_metric(report: dict[str, Any], metric: str, phase: str) -> float | 
 class AssertionEngine:
     """Evaluates a list of assertions against a harness report."""
 
-    def __init__(self, assertions: list[MetricAssertion]) -> None:
+    def __init__(self, assertions: Sequence[MetricAssertion]) -> None:
         self.assertions = assertions
 
     def evaluate(self, report: dict[str, Any], report_path: str = "") -> EvaluationResult:
         """Run all assertions against the report and return an aggregated result."""
         results: list[AssertionResult] = []
         for assertion in self.assertions:
-            if assertion.phase == "*":
-                value = _extract_metric(report, assertion.metric, "*")
-                results.append(assertion.evaluate(value))
-            else:
-                # Specific phase
-                value = _extract_metric(report, assertion.metric, assertion.phase)
-                results.append(assertion.evaluate(value))
+            value = _extract_metric(report, assertion.metric, assertion.phase)
+            results.append(assertion.evaluate(value))
 
         verdict = self._compute_verdict(results)
         return EvaluationResult(verdict=verdict, results=results, report_path=report_path)

--- a/src/roboharness/evaluate/batch.py
+++ b/src/roboharness/evaluate/batch.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import json
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion
-from roboharness.evaluate.result import EvaluationResult, Verdict
+from roboharness.evaluate.result import Verdict
 
 
 @dataclass
@@ -19,17 +20,15 @@ class TrialSummary:
     report_path: str
     case_id: str
     verdict: Verdict
-    original_verdict: str
     critical_failures: int
     major_failures: int
     failure_codes: list[str] = field(default_factory=list)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "report_path": self.report_path,
             "case_id": self.case_id,
             "verdict": self.verdict.value,
-            "original_verdict": self.original_verdict,
             "critical_failures": self.critical_failures,
             "major_failures": self.major_failures,
             "failure_codes": self.failure_codes,
@@ -37,7 +36,7 @@ class TrialSummary:
 
 
 @dataclass
-class BatchResult:
+class EvalBatchResult:
     """Aggregated results across multiple trials."""
 
     results_dir: str
@@ -47,9 +46,8 @@ class BatchResult:
     failure_distribution: dict[str, int] = field(default_factory=dict)
     constraint_failures: dict[str, int] = field(default_factory=dict)
     trials: list[TrialSummary] = field(default_factory=list)
-    per_evaluation: list[EvaluationResult] = field(default_factory=list)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "results_dir": self.results_dir,
             "total_trials": self.total_trials,
@@ -66,9 +64,9 @@ class VariantResult:
     """Results for a single variant (e.g. grasp position)."""
 
     variant_id: str
-    batch: BatchResult
+    batch: EvalBatchResult
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "variant_id": self.variant_id,
             **self.batch.to_dict(),
@@ -81,7 +79,7 @@ class ComparisonResult:
 
     variants: list[VariantResult] = field(default_factory=list)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "variants": [v.to_dict() for v in self.variants],
             "summary": {
@@ -102,8 +100,8 @@ def find_reports(results_dir: Path) -> list[Path]:
 
 def _load_report(path: Path) -> dict[str, Any]:
     with path.open() as f:
-        result: dict[str, Any] = json.load(f)
-        return result
+        data: dict[str, Any] = json.load(f)
+    return data
 
 
 def _failure_codes_from_report(report: dict[str, Any]) -> list[str]:
@@ -114,8 +112,8 @@ def _failure_codes_from_report(report: dict[str, Any]) -> list[str]:
 
 def evaluate_batch(
     results_dir: Path,
-    assertions: list[MetricAssertion],
-) -> BatchResult:
+    assertions: Sequence[MetricAssertion],
+) -> EvalBatchResult:
     """Evaluate all trial reports in a directory against constraints.
 
     Finds all ``autonomous_report.json`` files under *results_dir*, evaluates
@@ -128,15 +126,12 @@ def evaluate_batch(
     failure_code_counter: Counter[str] = Counter()
     constraint_counter: Counter[str] = Counter()
     trials: list[TrialSummary] = []
-    evaluations: list[EvaluationResult] = []
 
     for rpath in report_paths:
         report = _load_report(rpath)
         eval_result = engine.evaluate(report, report_path=str(rpath))
-        evaluations.append(eval_result)
 
         case_id = report.get("case_id", rpath.parent.name)
-        original_verdict = report.get("verdict", "unknown")
         failure_codes = _failure_codes_from_report(report)
 
         verdict_counter[eval_result.verdict.value] += 1
@@ -151,7 +146,6 @@ def evaluate_batch(
                 report_path=str(rpath),
                 case_id=case_id,
                 verdict=eval_result.verdict,
-                original_verdict=original_verdict,
                 critical_failures=len(eval_result.critical_failures),
                 major_failures=len(eval_result.major_failures),
                 failure_codes=failure_codes,
@@ -162,7 +156,7 @@ def evaluate_batch(
     pass_count = verdict_counter.get("pass", 0)
     success_rate = pass_count / total if total > 0 else 0.0
 
-    return BatchResult(
+    return EvalBatchResult(
         results_dir=str(results_dir),
         total_trials=total,
         verdicts=dict(verdict_counter),
@@ -170,13 +164,12 @@ def evaluate_batch(
         failure_distribution=dict(failure_code_counter),
         constraint_failures=dict(constraint_counter),
         trials=trials,
-        per_evaluation=evaluations,
     )
 
 
 def evaluate_batch_with_comparison(
     results_dir: Path,
-    assertions: list[MetricAssertion],
+    assertions: Sequence[MetricAssertion],
 ) -> ComparisonResult:
     """Evaluate trials grouped by variant (subdirectory) for comparison.
 
@@ -188,16 +181,15 @@ def evaluate_batch_with_comparison(
     subdirs = sorted(p for p in results_dir.iterdir() if p.is_dir())
 
     for subdir in subdirs:
-        reports = find_reports(subdir)
-        if not reports:
-            continue
         batch = evaluate_batch(subdir, assertions)
+        if batch.total_trials == 0:
+            continue
         variants.append(VariantResult(variant_id=subdir.name, batch=batch))
 
     return ComparisonResult(variants=variants)
 
 
-def format_batch_human(batch: BatchResult) -> str:
+def format_batch_human(batch: EvalBatchResult) -> str:
     """Format batch results for human-readable CLI output."""
     lines: list[str] = []
     lines.append(f"Batch evaluation: {batch.results_dir}")
@@ -243,13 +235,13 @@ def format_comparison_human(comparison: ComparisonResult) -> str:
 
 def _format_verdicts(verdicts: dict[str, int]) -> str:
     parts = []
-    for v in ["pass", "degraded", "fail"]:
-        if v in verdicts:
-            parts.append(f"{v}={verdicts[v]}")
+    for v in Verdict:
+        if v.value in verdicts:
+            parts.append(f"{v.value}={verdicts[v.value]}")
     return ", ".join(parts) if parts else "none"
 
 
-def check_success_rate(batch: BatchResult, min_rate: float) -> bool:
+def check_success_rate(batch: EvalBatchResult, min_rate: float) -> bool:
     """Check if the batch success rate meets a minimum threshold.
 
     Useful for CI integration: assert that >=80% of trials pass.

--- a/src/roboharness/evaluate/constraints.py
+++ b/src/roboharness/evaluate/constraints.py
@@ -59,7 +59,9 @@ def load_constraints(path: Path) -> list[MetricAssertion]:
     return [_parse_assertion(raw) for raw in raw_list]
 
 
-def save_constraints(assertions: list[MetricAssertion], path: Path) -> None:
+def save_constraints(
+    assertions: list[MetricAssertion] | tuple[MetricAssertion, ...], path: Path
+) -> None:
     """Save constraint assertions to a JSON file."""
     data = {
         "constraints": [

--- a/src/roboharness/evaluate/defaults.py
+++ b/src/roboharness/evaluate/defaults.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 from roboharness.evaluate.assertions import MetricAssertion
 from roboharness.evaluate.result import Operator, Severity
 
 # Default grasp constraints derived from real harness report thresholds.
-GRASP_DEFAULTS: list[MetricAssertion] = [
+GRASP_DEFAULTS: Final[tuple[MetricAssertion, ...]] = (
     MetricAssertion(
         metric="grip_center_error_mm",
         operator=Operator.LT,
@@ -35,4 +37,4 @@ GRASP_DEFAULTS: list[MetricAssertion] = [
         severity=Severity.MAJOR,
         phase="*",
     ),
-]
+)

--- a/src/roboharness/evaluate/result.py
+++ b/src/roboharness/evaluate/result.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass, field
+from typing import Any
 
 
 class Verdict(enum.Enum):
@@ -47,8 +48,7 @@ class AssertionResult:
     actual_value: float | None = None
     message: str = ""
 
-    def to_dict(self) -> dict:
-        """Serialize to dict."""
+    def to_dict(self) -> dict[str, Any]:
         threshold: float | list[float] = (
             list(self.threshold) if isinstance(self.threshold, tuple) else self.threshold
         )
@@ -88,15 +88,27 @@ class EvaluationResult:
     def major_failures(self) -> list[AssertionResult]:
         return [r for r in self.results if not r.passed and r.severity == Severity.MAJOR]
 
-    def to_dict(self) -> dict:
-        """Serialize to dict."""
+    def to_dict(self) -> dict[str, Any]:
+        passed_count = 0
+        failed_count = 0
+        critical_count = 0
+        major_count = 0
+        for r in self.results:
+            if r.passed:
+                passed_count += 1
+            else:
+                failed_count += 1
+                if r.severity == Severity.CRITICAL:
+                    critical_count += 1
+                elif r.severity == Severity.MAJOR:
+                    major_count += 1
         return {
             "verdict": self.verdict.value,
             "report_path": self.report_path,
             "total_assertions": len(self.results),
-            "passed": len(self.passed),
-            "failed": len(self.failed),
-            "critical_failures": len(self.critical_failures),
-            "major_failures": len(self.major_failures),
+            "passed": passed_count,
+            "failed": failed_count,
+            "critical_failures": critical_count,
+            "major_failures": major_count,
             "results": [r.to_dict() for r in self.results],
         }

--- a/src/roboharness/runner.py
+++ b/src/roboharness/runner.py
@@ -166,10 +166,13 @@ class ParallelTrialRunner:
         # Maintain insertion order so results[i] corresponds to specs[i].
         results: list[TrialResult | None] = [None] * len(specs)
 
+        def run_one(spec: TrialSpec) -> TrialResult:
+            backend = self.backend_factory()
+            output_dir = self.store.get_trial_dir(spec.variant_name, spec.trial_id)
+            return trial_fn(backend, output_dir, spec)
+
         with ThreadPoolExecutor(max_workers=min(self.max_workers, len(specs))) as executor:
-            future_to_idx = {
-                executor.submit(self._run_one, spec, trial_fn): i for i, spec in enumerate(specs)
-            }
+            future_to_idx = {executor.submit(run_one, spec): i for i, spec in enumerate(specs)}
             for future in as_completed(future_to_idx):
                 idx = future_to_idx[future]
                 spec = specs[idx]
@@ -186,15 +189,10 @@ class ParallelTrialRunner:
                 self.store.save_trial_result(spec.variant_name, result)
 
         total_duration = time.monotonic() - start
-        # All slots should be filled; the cast is safe.
+        # Every slot must be filled — assert rather than silently dropping.
+        assert all(r is not None for r in results), "BUG: unfilled result slot"
         return BatchResult(
-            results=[r for r in results if r is not None],
+            results=[r for r in results if r is not None],  # narrowing for type checker
             specs=list(specs),
             total_duration=total_duration,
         )
-
-    def _run_one(self, spec: TrialSpec, trial_fn: TrialFn) -> TrialResult:
-        """Create an isolated environment and execute one trial."""
-        backend = self.backend_factory()
-        output_dir = self.store.get_trial_dir(spec.variant_name, spec.trial_id)
-        return trial_fn(backend, output_dir, spec)

--- a/src/roboharness/storage/history.py
+++ b/src/roboharness/storage/history.py
@@ -104,11 +104,11 @@ class EvaluationHistory:
             return []
         records: list[EvaluationRecord] = []
         with self._path.open() as f:
-            for line in f:
-                line = line.strip()
-                if not line:
+            for raw_line in f:
+                stripped = raw_line.strip()
+                if not stripped:
                     continue
-                data = json.loads(line)
+                data = json.loads(stripped)
                 if task is None or data.get("task") == task:
                     records.append(EvaluationRecord.from_dict(data))
         return records
@@ -140,6 +140,59 @@ class EvaluationHistory:
             records.append(record)
         return records
 
+    def detect_trend(
+        self,
+        task: str,
+        current_rate: float,
+        window: int = 5,
+        threshold: float = 0.1,
+    ) -> TrendResult:
+        """Compare *current_rate* against the last *window* runs for *task*.
+
+        A regression is flagged when the current rate is more than *threshold*
+        below the average of recent history.
+        """
+        records = self.load(task=task)
+
+        if not records:
+            return TrendResult(
+                task=task,
+                current_rate=current_rate,
+                previous_rate=None,
+                delta=None,
+                window_size=0,
+                regressed=False,
+                message=f"No previous history for '{task}' — baseline recorded.",
+            )
+
+        recent = records[-window:]
+        avg_rate = sum(r.success_rate for r in recent) / len(recent)
+        delta = current_rate - avg_rate
+        regressed = delta < -threshold
+
+        if regressed:
+            msg = (
+                f"REGRESSION: '{task}' success rate dropped from "
+                f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
+            )
+        elif delta > threshold:
+            msg = (
+                f"IMPROVEMENT: '{task}' success rate rose from "
+                f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
+            )
+        else:
+            msg = f"'{task}' success rate stable at {current_rate:.0%} (avg {avg_rate:.0%})"
+
+        return TrendResult(
+            task=task,
+            current_rate=current_rate,
+            previous_rate=avg_rate,
+            delta=delta,
+            window_size=len(recent),
+            regressed=regressed,
+            message=msg,
+        )
+
 
 def detect_trend(
     history: EvaluationHistory,
@@ -148,48 +201,5 @@ def detect_trend(
     window: int = 5,
     threshold: float = 0.1,
 ) -> TrendResult:
-    """Compare *current_rate* against the last *window* runs for *task*.
-
-    A regression is flagged when the current rate is more than *threshold*
-    below the average of recent history.
-    """
-    records = history.load(task=task)
-
-    if not records:
-        return TrendResult(
-            task=task,
-            current_rate=current_rate,
-            previous_rate=None,
-            delta=None,
-            window_size=0,
-            regressed=False,
-            message=f"No previous history for '{task}' — baseline recorded.",
-        )
-
-    recent = records[-window:]
-    avg_rate = sum(r.success_rate for r in recent) / len(recent)
-    delta = current_rate - avg_rate
-    regressed = delta < -threshold
-
-    if regressed:
-        msg = (
-            f"REGRESSION: '{task}' success rate dropped from "
-            f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
-        )
-    elif delta > threshold:
-        msg = (
-            f"IMPROVEMENT: '{task}' success rate rose from "
-            f"{avg_rate:.0%} to {current_rate:.0%} (Δ{delta:+.0%})"
-        )
-    else:
-        msg = f"'{task}' success rate stable at {current_rate:.0%} (avg {avg_rate:.0%})"
-
-    return TrendResult(
-        task=task,
-        current_rate=current_rate,
-        previous_rate=avg_rate,
-        delta=delta,
-        window_size=len(recent),
-        regressed=regressed,
-        message=msg,
-    )
+    """Convenience wrapper — delegates to :meth:`EvaluationHistory.detect_trend`."""
+    return history.detect_trend(task, current_rate, window=window, threshold=threshold)

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -9,7 +9,7 @@ import pytest
 
 from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion, _extract_metric
 from roboharness.evaluate.batch import (
-    BatchResult,
+    EvalBatchResult,
     check_success_rate,
     evaluate_batch,
     evaluate_batch_with_comparison,
@@ -357,11 +357,11 @@ class TestBatchEvaluation:
         assert isinstance(d["trials"], list)
 
     def test_check_success_rate_pass(self) -> None:
-        batch = BatchResult(results_dir=".", total_trials=10, success_rate=0.85)
+        batch = EvalBatchResult(results_dir=".", total_trials=10, success_rate=0.85)
         assert check_success_rate(batch, 0.8)
 
     def test_check_success_rate_fail(self) -> None:
-        batch = BatchResult(results_dir=".", total_trials=10, success_rate=0.75)
+        batch = EvalBatchResult(results_dir=".", total_trials=10, success_rate=0.75)
         assert not check_success_rate(batch, 0.8)
 
     def test_empty_dir(self, tmp_path: Path) -> None:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -238,16 +238,6 @@ class TestTrendCommand:
         captured = capsys.readouterr()
         assert "pick_and_place" in captured.out
 
-    def test_trend_cli_report_flag(
-        self,
-        harness_output_with_results: Path,
-        capsys: pytest.CaptureFixture[str],
-    ) -> None:
-        ret = main(["report", "--trend", str(harness_output_with_results)])
-        assert ret == 0
-        captured = capsys.readouterr()
-        assert "Trend analysis" in captured.out
-
     def test_trend_regression_exit_code(self, tmp_path: Path) -> None:
         """Trend subcommand returns exit code 2 on regression."""
         # Build history with high success rate

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -111,7 +111,7 @@ def test_lifecycle_summary():
     assert s["horizon"] == "near_term"
     assert len(s["assumptions"]) == 1
     assert s["assumptions"][0]["evidence"] == "tested v3"
-    assert s["owner"] == "core-team"
+    assert s["metadata"]["owner"] == "core-team"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Rename evaluate.BatchResult to EvalBatchResult to resolve naming collision
  with runner.BatchResult
- Remove dead if/else branch in AssertionEngine.evaluate (both branches identical)
- Remove unused TrialSummary.original_verdict and EvalBatchResult.per_evaluation fields
- Fix double find_reports call in evaluate_batch_with_comparison
- Optimize EvaluationResult.to_dict() from 6 passes to single pass
- Make GRASP_DEFAULTS an immutable tuple instead of mutable list
- Use Sequence[MetricAssertion] to accept both lists and tuples
- Add proper dict[str, Any] return type annotations on all to_dict methods
- Use Verdict enum in _format_verdicts instead of hardcoded string list
- Merge is_expired guard conditions in lifecycle.py
- Fix summary() metadata shadowing by nesting under 'metadata' key
- Inline _build_default_registry into module-level registration
- Make detect_trend a method on EvaluationHistory (keep wrapper for compat)
- Fix line variable shadowing in EvaluationHistory.load
- Remove --trend flag from report command (use trend subcommand instead)
- Merge _find_metadata_files/_find_result_files/_find_image_files into _find_files
- Add assertion for unfilled result slots in ParallelTrialRunner
- Inline _run_one into closure in ParallelTrialRunner.run
- Update all tests to match refactored APIs

https://claude.ai/code/session_01HimNUUCqcZmHSWPMDV24zb