### PR TITLE
fix: correct qpos index for cube z-position in grasp assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         run: python examples/mujoco_grasp.py --report --assert-success --output-dir ./harness_output
 
       - name: Upload visual artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: mujoco-grasp-output
@@ -86,6 +87,7 @@ jobs:
           retention-days: 30
 
       - name: Post summary with checkpoint images
+        if: always()
         run: |
           echo "## MuJoCo Grasp Example Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/examples/mujoco_grasp.py
+++ b/examples/mujoco_grasp.py
@@ -429,14 +429,13 @@ QVEL_MAX = 50.0  # maximum acceptable qvel magnitude (stability check)
 def _get_cube_z(state: dict[str, object]) -> float:
     """Extract cube center z-position from simulator state.
 
-    The cube is the first free body, its qpos starts at index 0 of the
-    free joint DOFs. In this model: qpos layout is [gripper_z, finger_left,
-    finger_right, cube_x, cube_y, cube_z, cube_qw, cube_qx, cube_qy, cube_qz].
-    The cube free joint contributes 7 DOFs (3 pos + 4 quat), and the 3 slide
-    joints come first. So cube z = qpos[5].
+    MuJoCo orders free joints before slide joints in qpos. In this model:
+    qpos[0:3] = cube position (x, y, z), qpos[3:7] = cube quaternion,
+    qpos[7] = gripper_z, qpos[8] = finger_left, qpos[9] = finger_right.
+    So cube z = qpos[2].
     """
     qpos = state["qpos"]
-    return float(qpos[5])
+    return float(qpos[2])
 
 
 def assert_grasp_success(


### PR DESCRIPTION
The _get_cube_z helper read qpos[5] assuming slide joints came before
the free joint in MuJoCo's qpos array. MuJoCo actually orders free
joints first, so the cube position is at qpos[0:3] and cube z is
qpos[2]. This caused --assert-success to always see cube z ≈ 0 and
fail, breaking CI since the flag was added.

Also add if: always() to artifact upload and summary steps so
diagnostics are available even when assertions fail.

https://claude.ai/code/session_01JCLzhyswgBavhQ1yA7c3MT