### PR TITLE
refactor: raise coverage threshold to 90% and document TDD philosophy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,11 @@ Do NOT create a new branch or a new PR for review fixes.
 
 ## Testing philosophy
 
+- **Test-driven development.** Write tests first, then implement. This ensures every feature has coverage from the start and avoids the "write tests later" debt that never gets paid. When adding a new module or function, start with the test file.
+- **Coverage threshold: 90%+.** CI enforces a minimum coverage threshold (see `pyproject.toml`). New code must not lower overall coverage. If you add code, add tests for it in the same PR.
 - **Real tests, not stub theater.** Unit tests must correlate with actual scenarios. Minimize mocks; only stub truly external/expensive operations (network, hardware, GPU). If UTs pass but E2E fails, the UTs are misleading.
 - **Visualization-based validation.** Logs miss things visual inspection catches instantly (wrong transforms, flipped axes, geometry errors). Add vis-based validation alongside numeric tests when the project supports it (MuJoCo viewer, Meshcat, Rerun).
+- **Coverage omit is for genuine hardware deps only.** Files in `[tool.coverage.run] omit` must require hardware or optional heavy dependencies (MuJoCo, GPU, Pinocchio) that aren't in `[dev]`. Don't omit files just because tests haven't been written — that hides debt.
 - After each significant change, verify related tests still pass before moving on.
 
 ## Core principles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,17 @@ ignore = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=roboharness --cov-report=term-missing --cov-fail-under=70"
+addopts = "--cov=roboharness --cov-report=term-missing --cov-fail-under=90"
 
 [tool.coverage.run]
+# Omit files requiring optional heavy deps not in [dev].
+# These are covered by specialized CI jobs (test-mujoco) or need GPU/hardware.
+# Do NOT add files here just because tests haven't been written.
 omit = [
-    "src/roboharness/backends/mujoco_meshcat.py",
-    "src/roboharness/backends/visualizer.py",
-    "src/roboharness/controllers/wbc_ik.py",
-    "src/roboharness/wrappers/gymnasium_wrapper.py",
+    "src/roboharness/backends/mujoco_meshcat.py",   # requires mujoco
+    "src/roboharness/backends/visualizer.py",        # requires mujoco / meshcat
+    "src/roboharness/controllers/wbc_ik.py",         # requires pinocchio + pink
+    "src/roboharness/wrappers/gymnasium_wrapper.py", # requires gymnasium
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

- Raise `--cov-fail-under` from 70% to 90% (actual coverage is 93%, so 70% was a no-op gate)
- Add TDD guidance to CLAUDE.md: write tests first, new code must maintain coverage, omit list is strictly for hardware deps
- Add inline comments to coverage omit list explaining why each file is excluded

## Context

The previous 70% threshold was set as a placeholder and never caught regressions — actual coverage was already 93%. Raising to 90% means new code without tests will be blocked by CI. The CLAUDE.md updates ensure agents follow test-driven development going forward.

## Coverage omit rationale

All four omitted files require optional heavy dependencies not in `[dev]`:
| File | Dependency | Covered by |
|---|---|---|
| `mujoco_meshcat.py` | mujoco | `test-mujoco` CI job |
| `visualizer.py` | mujoco / meshcat | `test-mujoco` CI job (partial) |
| `wbc_ik.py` | pinocchio + pink | No CI job yet |
| `gymnasium_wrapper.py` | gymnasium | Tests exist but skip without gym |

## Test plan

- [x] `ruff check .` + `ruff format --check .` pass
- [x] `mypy src/` passes
- [x] `pytest` passes with 93% coverage (above new 90% threshold)

https://claude.ai/code/session_01JCLzhyswgBavhQ1yA7c3MT