### PR TITLE
feat: export evaluate public API and add __main__.py entry point

### DIFF
--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -13,10 +13,13 @@ from roboharness.core.lifecycle import (
     LifecycleRegistry,
     default_registry,
 )
+from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion
+from roboharness.evaluate.result import EvaluationResult, Operator, Severity, Verdict
 from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
 from roboharness.storage.history import EvaluationHistory, EvaluationRecord, TrendResult
 
 __all__ = [
+    "AssertionEngine",
     "BatchResult",
     "CaptureResult",
     "Checkpoint",
@@ -26,11 +29,16 @@ __all__ = [
     "Controller",
     "EvaluationHistory",
     "EvaluationRecord",
+    "EvaluationResult",
     "ExpirationHorizon",
     "Harness",
     "LifecycleRegistry",
+    "MetricAssertion",
+    "Operator",
     "ParallelTrialRunner",
+    "Severity",
     "TrendResult",
     "TrialSpec",
+    "Verdict",
     "default_registry",
 ]

--- a/src/roboharness/evaluate/__main__.py
+++ b/src/roboharness/evaluate/__main__.py
@@ -1,0 +1,10 @@
+"""Allow running the evaluator as ``python -m roboharness.evaluate``."""
+
+from __future__ import annotations
+
+import sys
+
+from roboharness.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["evaluate", *sys.argv[1:]]))


### PR DESCRIPTION
Export MetricAssertion, AssertionEngine, EvaluationResult, Verdict,
Severity, and Operator from the top-level roboharness package so users
can import them directly. Add __main__.py to enable
`python -m roboharness.evaluate` as a standalone CLI entry point.

Closes #68

https://claude.ai/code/session_01HUuYZhzfUMZF5sLfeZ9TEJ