### PR TITLE
feat: add native LeRobot integration via make_env() (#83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,41 @@ jobs:
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "Download the full artifact (including HTML report) from the Actions tab." >> $GITHUB_STEP_SUMMARY
 
+  lerobot-g1-native-example:
+    runs-on: ubuntu-latest
+    # Native LeRobot requires torch + lerobot — heavy install, allowed to fail
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install system dependencies (OSMesa for headless rendering)
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
+
+      - name: Install CPU-only PyTorch (lighter than default CUDA build)
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install package with native LeRobot dependencies
+        run: pip install -e ".[lerobot-native]" Pillow
+
+      - name: Run native LeRobot G1 example
+        env:
+          MUJOCO_GL: osmesa
+        run: python examples/lerobot_g1_native.py --report --assert-success --output-dir ./harness_output
+
+      - name: Upload visual artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lerobot-g1-native-output
+          path: |
+            harness_output/lerobot_g1_native_report.html
+            harness_output/lerobot_g1_native/trial_001/**/*_rgb.png
+            harness_output/lerobot_g1_native/trial_001/**/metadata.json
+          retention-days: 30
+
   lerobot-g1-example:
     runs-on: ubuntu-latest
     steps:

--- a/examples/lerobot_g1_native.py
+++ b/examples/lerobot_g1_native.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Native LeRobot G1 Integration — using LeRobot's official make_env() factory.
+
+Uses LeRobot's `make_env()` to create the Unitree G1 MuJoCo environment via the
+official digital-twin pipeline (DDS-ready), then wraps it with RobotHarnessWrapper
+for visual checkpoint capture.
+
+This replaces the manual asset-download approach in `lerobot_g1.py` with the
+official LeRobot factory, enabling:
+  - Standardized env creation via HuggingFace Hub
+  - DDS communication for sim-to-real transfer (when hardware available)
+  - Consistent observation/action spaces defined by the env config
+
+Requirements:
+    # CPU-only (lighter install):
+    pip install torch --index-url https://download.pytorch.org/whl/cpu
+    pip install roboharness[lerobot-native] Pillow
+
+    # Or full GPU:
+    pip install roboharness[lerobot-native] Pillow
+
+Run:
+    MUJOCO_GL=osmesa python examples/lerobot_g1_native.py
+
+Output:
+    ./harness_output/lerobot_g1_native/trial_001/
+        initial/   — env after reset
+        mid/       — midpoint of episode
+        final/     — end of episode
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+
+try:
+    import gymnasium as gym
+except ImportError:
+    print("ERROR: gymnasium is required. Install with: pip install gymnasium")
+    sys.exit(1)
+
+from roboharness.wrappers import RobotHarnessWrapper
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LEROBOT_ENV_ID = "lerobot/unitree-g1-mujoco"
+DEFAULT_N_STEPS = 500
+
+
+# ---------------------------------------------------------------------------
+# Environment creation via make_env()
+# ---------------------------------------------------------------------------
+
+
+def create_native_env(
+    env_id: str = LEROBOT_ENV_ID,
+    *,
+    n_envs: int = 1,
+) -> gym.Env:
+    """Create a LeRobot environment using the official make_env() factory.
+
+    ``make_env()`` returns ``dict[str, dict[int, VectorEnv]]``.  We extract
+    the single underlying environment for direct Gymnasium usage.
+    """
+    try:
+        from lerobot.envs.factory import make_env
+    except ImportError:
+        print(
+            "ERROR: lerobot is required for native integration.\n"
+            "Install with:\n"
+            "  pip install torch --index-url https://download.pytorch.org/whl/cpu\n"
+            "  pip install roboharness[lerobot-native] Pillow"
+        )
+        sys.exit(1)
+
+    env_dict = make_env(env_id, n_envs=n_envs, trust_remote_code=True)
+
+    # Extract the VectorEnv from the nested dict structure
+    # make_env returns {suite_name: {index: VectorEnv}}
+    for suite_name, index_map in env_dict.items():
+        for idx, vec_env in index_map.items():
+            print(f"      Suite: {suite_name}, index: {idx}")
+            print(f"      VectorEnv type: {type(vec_env).__name__}")
+            print(f"      Obs space: {vec_env.single_observation_space}")
+            print(f"      Act space: {vec_env.single_action_space}")
+
+            # For n_envs=1, unwrap the VectorEnv to get a single env
+            # VectorEnv wraps the env — we use it directly as it's Gymnasium-compatible
+            return _VectorEnvAdapter(vec_env)
+
+    msg = f"make_env('{env_id}') returned empty dict"
+    raise RuntimeError(msg)
+
+
+class _VectorEnvAdapter(gym.Env):
+    """Thin adapter from VectorEnv (n=1) to standard Gymnasium Env interface.
+
+    LeRobot's ``make_env()`` always returns a ``VectorEnv``, even for ``n_envs=1``.
+    This adapter unwraps the batch dimension so ``RobotHarnessWrapper`` sees a
+    standard single-env interface: scalar reward, 1-D/2-D obs (not batched), etc.
+    """
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": ["rgb_array"], "render_fps": 50}
+
+    def __init__(self, vec_env: gym.vector.VectorEnv) -> None:
+        super().__init__()
+        self._vec_env = vec_env
+        self.observation_space = vec_env.single_observation_space
+        self.action_space = vec_env.single_action_space
+        self.render_mode = "rgb_array"
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[Any, dict[str, Any]]:
+        obs, info = self._vec_env.reset(seed=seed, options=options)
+        return _unbatch(obs), _unbatch_info(info)
+
+    def step(self, action: Any) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        # Add batch dimension for VectorEnv
+        batched_action = np.expand_dims(np.asarray(action), axis=0)
+        obs, reward, terminated, truncated, info = self._vec_env.step(batched_action)
+        return (
+            _unbatch(obs),
+            float(reward[0]) if hasattr(reward, "__getitem__") else float(reward),
+            bool(terminated[0]) if hasattr(terminated, "__getitem__") else bool(terminated),
+            bool(truncated[0]) if hasattr(truncated, "__getitem__") else bool(truncated),
+            _unbatch_info(info),
+        )
+
+    def render(self) -> np.ndarray | None:
+        frames = self._vec_env.render()
+        if frames is not None and len(frames) > 0:
+            return frames[0] if hasattr(frames, "__getitem__") else frames
+        return None
+
+    def close(self) -> None:
+        self._vec_env.close()
+
+
+def _unbatch(obs: Any) -> Any:
+    """Remove batch dimension from observation."""
+    if isinstance(obs, dict):
+        return {k: _unbatch(v) for k, v in obs.items()}
+    if isinstance(obs, np.ndarray) and obs.ndim > 0:
+        return obs[0]
+    if hasattr(obs, "__getitem__"):
+        return obs[0]
+    return obs
+
+
+def _unbatch_info(info: dict[str, Any]) -> dict[str, Any]:
+    """Remove batch dimension from info dict values."""
+    out: dict[str, Any] = {}
+    for k, v in info.items():
+        if isinstance(v, np.ndarray) and v.ndim > 0 and v.shape[0] == 1:
+            out[k] = v[0]
+        elif isinstance(v, dict):
+            out[k] = _unbatch_info(v)
+        else:
+            out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_integration(
+    checkpoint_infos: list[dict[str, Any]],
+    expected_count: int,
+) -> list[str]:
+    """Validate that the wrapper integration worked correctly."""
+    failures: list[str] = []
+
+    if len(checkpoint_infos) != expected_count:
+        failures.append(f"Expected {expected_count} checkpoints, got {len(checkpoint_infos)}")
+
+    for cp_info in checkpoint_infos:
+        files = cp_info.get("files", {})
+        state_path = files.get("state")
+        if not state_path or not Path(state_path).exists():
+            failures.append(f"Checkpoint '{cp_info['name']}': missing state.json")
+            continue
+
+        state = json.loads(Path(state_path).read_text())
+        if "step" not in state or "reward" not in state:
+            failures.append(f"Checkpoint '{cp_info['name']}': state.json missing required fields")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# HTML report
+# ---------------------------------------------------------------------------
+
+
+def generate_html_report(output_dir: Path) -> Path:
+    """Generate a self-contained HTML report with embedded checkpoint images."""
+    from roboharness.reporting import generate_html_report as _generate
+
+    return _generate(
+        output_dir,
+        "lerobot_g1_native",
+        title="LeRobot G1 Native Integration Report",
+        accent_color="#00b894",
+        summary_html=(
+            f"<strong>Env:</strong> <code>{LEROBOT_ENV_ID}</code> via <code>make_env()</code>"
+            "<br/><strong>Integration:</strong> Native LeRobot factory + RobotHarnessWrapper"
+        ),
+        footer_text="Generated by <code>examples/lerobot_g1_native.py --report</code>",
+        meshcat_mode="none",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Native LeRobot G1 integration via make_env() + RobotHarnessWrapper"
+    )
+    parser.add_argument("--output-dir", default="./harness_output", help="Output directory")
+    parser.add_argument("--report", action="store_true", help="Generate HTML report")
+    parser.add_argument("--n-steps", type=int, default=DEFAULT_N_STEPS, help="Number of steps")
+    parser.add_argument(
+        "--assert-success", action="store_true", help="Exit non-zero on validation failure"
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    n_steps = args.n_steps
+
+    print("=" * 60)
+    print("  Roboharness: Native LeRobot G1 Integration")
+    print("=" * 60)
+
+    # 1. Create environment via make_env()
+    print(f"\n[1/4] Creating environment via make_env('{LEROBOT_ENV_ID}') ...")
+    env = create_native_env(LEROBOT_ENV_ID)
+    print(f"      Obs space: {env.observation_space}")
+    print(f"      Act space: {env.action_space}")
+
+    # 2. Wrap with RobotHarnessWrapper
+    print("[2/4] Wrapping with RobotHarnessWrapper ...")
+    cp_steps = [1, n_steps // 2, n_steps]
+    checkpoints = [
+        {"name": "initial", "step": cp_steps[0]},
+        {"name": "mid", "step": cp_steps[1]},
+        {"name": "final", "step": cp_steps[2]},
+    ]
+
+    # Detect available cameras — try render_camera if available
+    cameras = ["default"]
+    unwrapped = getattr(env, "unwrapped", env)
+    if hasattr(unwrapped, "cameras"):
+        cameras = list(unwrapped.cameras)
+    elif hasattr(unwrapped, "_cameras"):
+        cameras = list(unwrapped._cameras)
+
+    wrapped = RobotHarnessWrapper(
+        env,
+        checkpoints=checkpoints,
+        cameras=cameras,
+        output_dir=str(output_dir),
+        task_name="lerobot_g1_native",
+    )
+    print(f"      Multi-camera: {wrapped.has_multi_camera}")
+    print(f"      Camera capability: {wrapped.camera_capability}")
+    print(f"      Cameras: {cameras}")
+
+    # 3. Run episode
+    print(f"[3/4] Running episode ({n_steps} steps) ...")
+    obs, _info = wrapped.reset()
+    print(f"      Initial obs type: {type(obs).__name__}", end="")
+    if hasattr(obs, "shape"):
+        print(f", shape: {obs.shape}", end="")
+    elif isinstance(obs, dict):
+        print(f", keys: {list(obs.keys())}", end="")
+    print()
+
+    checkpoint_infos: list[dict[str, Any]] = []
+    for i in range(n_steps):
+        action = env.action_space.sample()
+        obs, reward, terminated, truncated, info = wrapped.step(action)
+
+        if "checkpoint" in info:
+            cp = info["checkpoint"]
+            checkpoint_infos.append(cp)
+            print(f"      Checkpoint '{cp['name']}' at step {cp['step']} | reward={reward:.3f}")
+            print(f"        -> {cp['capture_dir']}")
+
+        if terminated or truncated:
+            print(f"      Episode ended at step {i + 1} (terminated={terminated})")
+            obs, _info = wrapped.reset()
+
+    # 4. Validate
+    print("[4/4] Validating integration ...")
+    failures = validate_integration(checkpoint_infos, expected_count=len(checkpoints))
+
+    if failures:
+        print("      VALIDATION FAILED:")
+        for msg in failures:
+            print(f"        FAIL: {msg}")
+    else:
+        print("      All checks passed!")
+
+    # Summary
+    trial_dir = output_dir / "lerobot_g1_native" / "trial_001"
+    total_images = len(list(trial_dir.rglob("*_rgb.png"))) if trial_dir.exists() else 0
+    print(f"      {total_images} images saved to: {trial_dir}")
+
+    if args.report:
+        report_path = generate_html_report(output_dir)
+        print(f"      HTML report: {report_path}")
+
+    print("\n  Output structure:")
+    if trial_dir.exists():
+        for cp_dir in sorted(trial_dir.iterdir()):
+            if cp_dir.is_dir():
+                files = sorted(f.name for f in cp_dir.iterdir() if f.is_file())
+                print(f"    {cp_dir.name}/")
+                for fname in files:
+                    print(f"      {fname}")
+
+    print("\n" + "=" * 60)
+    wrapped.close()
+
+    if args.assert_success and failures:
+        print("\n  VALIDATION: FAILED")
+        sys.exit(1)
+    elif args.assert_success:
+        print("\n  VALIDATION: PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,11 @@ lerobot = [
     "huggingface_hub>=0.20",
     "onnxruntime>=1.16",
 ]
+lerobot-native = [
+    "lerobot",
+    "mujoco>=3.0",
+    "gymnasium>=0.29",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
@@ -66,7 +71,7 @@ dev = [
     "pre-commit>=3.0",
 ]
 all = [
-    "roboharness[mujoco,meshcat,rerun,lerobot,wbc,unitree,dev]",
+    "roboharness[mujoco,meshcat,rerun,lerobot,lerobot-native,wbc,unitree,dev]",
 ]
 
 [project.scripts]
@@ -138,5 +143,6 @@ module = [
     "onnxruntime.*",
     "huggingface_hub.*",
     "unitree_sdk2py.*",
+    "lerobot.*",
 ]
 ignore_missing_imports = true

--- a/tests/test_lerobot_native_compat.py
+++ b/tests/test_lerobot_native_compat.py
@@ -1,0 +1,321 @@
+"""Tests for native LeRobot integration — validates VectorEnv adapter + RobotHarnessWrapper.
+
+The native LeRobot path uses ``make_env()`` which returns a ``VectorEnv``.
+The ``_VectorEnvAdapter`` in ``examples/lerobot_g1_native.py`` unbatches it
+into a standard Gymnasium Env.
+
+These tests use real Gymnasium VectorEnvs (no mocks) to validate:
+  - VectorEnv (n=1) is correctly unbatched to single-env interface
+  - Dict observations are unbatched per-key
+  - RobotHarnessWrapper captures checkpoints through the adapter
+  - Validation logic in the example works correctly
+
+No LeRobot or MuJoCo installation is required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+import pytest
+
+gym = pytest.importorskip("gymnasium", reason="gymnasium not installed")
+
+from gymnasium import spaces  # noqa: E402
+
+from roboharness.wrappers import RobotHarnessWrapper  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Real lightweight Gymnasium envs for testing
+# ---------------------------------------------------------------------------
+
+
+class SimpleG1Env(gym.Env):
+    """Lightweight single env matching G1 dimensions (99-dim obs, 29-dim act)."""
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": ["rgb_array"], "render_fps": 50}
+
+    def __init__(self, render_mode: str = "rgb_array"):
+        super().__init__()
+        self.render_mode = render_mode
+        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(99,), dtype=np.float64)
+        self.action_space = spaces.Box(low=-np.pi, high=np.pi, shape=(29,), dtype=np.float64)
+        self._step_count = 0
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        self._step_count = 0
+        return np.zeros(99, dtype=np.float64), {}
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        self._step_count += 1
+        rng = np.random.default_rng(self._step_count)
+        obs = rng.standard_normal(99).astype(np.float64) * 0.1
+        return obs, 1.75, False, False, {"sim_time": self._step_count * 0.004}
+
+    def render(self) -> np.ndarray:
+        return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+class DictObsEnv(gym.Env):
+    """Env with dict observations (common in LeRobot policy envs)."""
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": ["rgb_array"], "render_fps": 50}
+
+    def __init__(self, render_mode: str = "rgb_array"):
+        super().__init__()
+        self.render_mode = render_mode
+        self.observation_space = spaces.Dict(
+            {
+                "observation.state": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(29,), dtype=np.float32
+                ),
+                "observation.images.head": spaces.Box(
+                    low=0, high=255, shape=(64, 64, 3), dtype=np.uint8
+                ),
+            }
+        )
+        self.action_space = spaces.Box(low=-np.pi, high=np.pi, shape=(29,), dtype=np.float64)
+        self._step_count = 0
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        self._step_count = 0
+        obs = {
+            "observation.state": np.zeros(29, dtype=np.float32),
+            "observation.images.head": np.zeros((64, 64, 3), dtype=np.uint8),
+        }
+        return obs, {}
+
+    def step(
+        self, action: np.ndarray
+    ) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+        self._step_count += 1
+        obs = {
+            "observation.state": np.ones(29, dtype=np.float32) * 0.1,
+            "observation.images.head": np.ones((64, 64, 3), dtype=np.uint8) * 128,
+        }
+        return obs, 1.0, False, False, {}
+
+    def render(self) -> np.ndarray:
+        return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: import the example module
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def native_module():
+    """Import examples/lerobot_g1_native.py as a module."""
+    example_path = Path(__file__).parent.parent / "examples"
+    sys.path.insert(0, str(example_path))
+    try:
+        import lerobot_g1_native
+
+        yield lerobot_g1_native
+    finally:
+        sys.path.pop(0)
+        sys.modules.pop("lerobot_g1_native", None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: VectorEnv adapter unbatching
+# ---------------------------------------------------------------------------
+
+
+def _make_vector_env(env_fn):
+    """Create a real SyncVectorEnv with n=1 from an env factory."""
+    return gym.vector.SyncVectorEnv([env_fn])
+
+
+class TestVectorEnvAdapter:
+    """Tests for _VectorEnvAdapter with real SyncVectorEnv."""
+
+    def test_reset_unbatches_flat_obs(self, native_module):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        obs, _info = adapter.reset()
+
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == (99,)
+
+    def test_step_returns_scalars(self, native_module):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        adapter.reset()
+
+        action = np.zeros(29, dtype=np.float64)
+        obs, reward, terminated, truncated, _info = adapter.step(action)
+
+        assert obs.shape == (99,)
+        assert isinstance(reward, float)
+        assert abs(reward - 1.75) < 0.01
+        assert terminated is False
+        assert truncated is False
+
+    def test_render_single_frame(self, native_module):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        adapter.reset()
+        frame = adapter.render()
+
+        assert isinstance(frame, np.ndarray)
+        assert frame.shape == (480, 640, 3)
+
+    def test_dict_obs_unbatched(self, native_module):
+        vec_env = _make_vector_env(DictObsEnv)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        obs, _info = adapter.reset()
+
+        assert isinstance(obs, dict)
+        assert obs["observation.state"].shape == (29,)
+        assert obs["observation.images.head"].shape == (64, 64, 3)
+
+    def test_spaces_are_single(self, native_module):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+
+        assert adapter.observation_space.shape == (99,)
+        assert adapter.action_space.shape == (29,)
+
+    def test_close(self, native_module):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        adapter.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Tests: RobotHarnessWrapper through adapter
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperWithAdapter:
+    """RobotHarnessWrapper integration with VectorEnvAdapter."""
+
+    def test_checkpoint_captured(self, native_module, tmp_path):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 3}],
+            output_dir=tmp_path,
+            task_name="native_test",
+        )
+        wrapped.reset()
+        for _ in range(3):
+            _, _, _, _, info = wrapped.step(np.zeros(29))
+
+        assert "checkpoint" in info
+        state_path = tmp_path / "native_test" / "trial_001" / "cp" / "state.json"
+        assert state_path.exists()
+        state = json.loads(state_path.read_text())
+        assert state["step"] == 3
+        assert isinstance(state["reward"], float)
+
+    def test_obs_passthrough(self, native_module, tmp_path):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 100}],
+            output_dir=tmp_path,
+        )
+        obs, _ = wrapped.reset()
+        assert obs.shape == (99,)
+
+        obs, reward, _, _, _ = wrapped.step(np.zeros(29))
+        assert obs.shape == (99,)
+        assert isinstance(reward, float)
+
+    def test_dict_obs_records_keys(self, native_module, tmp_path):
+        vec_env = _make_vector_env(DictObsEnv)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 1}],
+            output_dir=tmp_path,
+            task_name="dict_obs",
+        )
+        wrapped.reset()
+        wrapped.step(np.zeros(29))
+
+        state_path = tmp_path / "dict_obs" / "trial_001" / "cp" / "state.json"
+        state = json.loads(state_path.read_text())
+        assert "obs_keys" in state
+        assert "observation.state" in state["obs_keys"]
+
+    def test_multiple_checkpoints(self, native_module, tmp_path):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[
+                {"name": "initial", "step": 1},
+                {"name": "mid", "step": 5},
+                {"name": "final", "step": 10},
+            ],
+            output_dir=tmp_path,
+            task_name="multi_cp",
+        )
+        wrapped.reset()
+
+        captured = []
+        for _ in range(10):
+            _, _, _, _, info = wrapped.step(np.zeros(29))
+            if "checkpoint" in info:
+                captured.append(info["checkpoint"]["name"])
+
+        assert captured == ["initial", "mid", "final"]
+
+    def test_render_image_saved(self, native_module, tmp_path):
+        vec_env = _make_vector_env(SimpleG1Env)
+        adapter = native_module._VectorEnvAdapter(vec_env)
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 1}],
+            output_dir=tmp_path,
+            task_name="render_test",
+        )
+        wrapped.reset()
+        wrapped.step(np.zeros(29))
+
+        capture_dir = tmp_path / "render_test" / "trial_001" / "cp"
+        image_files = list(capture_dir.glob("*_rgb.*"))
+        assert len(image_files) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: validation logic
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    """Tests for validate_integration in the example."""
+
+    def test_valid_checkpoints_pass(self, native_module, tmp_path):
+        cp_dir = tmp_path / "cp1"
+        cp_dir.mkdir()
+        (cp_dir / "state.json").write_text(json.dumps({"step": 1, "reward": 1.5}))
+
+        infos = [{"name": "cp1", "step": 1, "files": {"state": str(cp_dir / "state.json")}}]
+        failures = native_module.validate_integration(infos, expected_count=1)
+        assert failures == []
+
+    def test_wrong_count_fails(self, native_module):
+        failures = native_module.validate_integration([], expected_count=3)
+        assert any("Expected 3" in f for f in failures)
+
+    def test_missing_state_fails(self, native_module):
+        infos = [{"name": "cp1", "step": 1, "files": {"state": "/nonexistent/state.json"}}]
+        failures = native_module.validate_integration(infos, expected_count=1)
+        assert any("missing state.json" in f for f in failures)


### PR DESCRIPTION
Add examples/lerobot_g1_native.py that uses LeRobot's official
make_env() factory instead of manually downloading HF assets.
Includes VectorEnvAdapter to unbatch n=1 VectorEnv to standard
Gymnasium Env, [lerobot-native] optional dep group, CI job
(continue-on-error due to heavy torch dep), and 14 tests using
real SyncVectorEnv (no mocks).

https://claude.ai/code/session_01PEhJhQTF1KfZdLRuERBUK7