### PR TITLE
feat: add semantic task protocols for meaningful checkpoint phases

### DIFF
--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -13,12 +13,26 @@ from roboharness.core.lifecycle import (
     LifecycleRegistry,
     default_registry,
 )
+from roboharness.core.protocol import (
+    BUILTIN_PROTOCOLS,
+    DANCE_PROTOCOL,
+    GRASP_PROTOCOL,
+    LOCO_MANIPULATION_PROTOCOL,
+    LOCOMOTION_PROTOCOL,
+    TaskPhase,
+    TaskProtocol,
+)
 from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion
 from roboharness.evaluate.result import EvaluationResult, Operator, Severity, Verdict
 from roboharness.runner import BatchResult, ParallelTrialRunner, TrialSpec
 from roboharness.storage.history import EvaluationHistory, EvaluationRecord, TrendResult
 
 __all__ = [
+    "BUILTIN_PROTOCOLS",
+    "DANCE_PROTOCOL",
+    "GRASP_PROTOCOL",
+    "LOCOMOTION_PROTOCOL",
+    "LOCO_MANIPULATION_PROTOCOL",
     "AssertionEngine",
     "BatchResult",
     "CaptureResult",
@@ -37,6 +51,8 @@ __all__ = [
     "Operator",
     "ParallelTrialRunner",
     "Severity",
+    "TaskPhase",
+    "TaskProtocol",
     "TrendResult",
     "TrialSpec",
     "Verdict",

--- a/src/roboharness/core/harness.py
+++ b/src/roboharness/core/harness.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from roboharness.core.capture import CameraView, CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore
+from roboharness.core.protocol import TaskProtocol
 from roboharness.core.rerun_logger import RerunCaptureLogger
 
 
@@ -86,6 +87,7 @@ class Harness:
         self._trial_count: int = 0
         self._checkpoint_store = CheckpointStore(self.output_dir / "snapshots")
         self._rerun_logger = RerunCaptureLogger(app_id=rerun_app_id) if enable_rerun else None
+        self._active_protocol: TaskProtocol | None = None
 
     # ---- Checkpoint management ----
 
@@ -106,6 +108,40 @@ class Harness:
             metadata=metadata,
         )
         self._checkpoints.append(cp)
+
+    def load_protocol(
+        self,
+        protocol: TaskProtocol,
+        phases: list[str] | None = None,
+    ) -> None:
+        """Load a semantic task protocol, registering its phases as checkpoints.
+
+        This replaces any previously registered checkpoints. Each phase in the
+        protocol becomes a checkpoint with the phase's camera configuration
+        and metadata.
+
+        Args:
+            protocol: The task protocol to load.
+            phases: Optional subset of phase names to use. If None, all phases
+                are loaded. Order follows the ``phases`` list if provided.
+        """
+        if phases is not None:
+            protocol = protocol.select(phases)
+
+        self._checkpoints.clear()
+        self._active_protocol = protocol
+
+        for phase in protocol.phases:
+            self.add_checkpoint(
+                name=phase.name,
+                cameras=phase.cameras,
+                **phase.metadata,
+            )
+
+    @property
+    def active_protocol(self) -> TaskProtocol | None:
+        """The currently loaded task protocol, or None."""
+        return self._active_protocol
 
     # ---- Core loop ----
 

--- a/src/roboharness/core/protocol.py
+++ b/src/roboharness/core/protocol.py
@@ -1,0 +1,158 @@
+"""Semantic task protocols — define meaningful capture phases for robot tasks.
+
+Instead of capturing at arbitrary simulation step counts, a TaskProtocol defines
+semantically meaningful phases (e.g. "pre_grasp", "approach", "grasp", "lift")
+that map to the natural structure of a task.
+
+Usage:
+    from roboharness.core.protocol import GRASP_PROTOCOL, TaskProtocol, TaskPhase
+
+    # Use a built-in protocol
+    harness.load_protocol(GRASP_PROTOCOL)
+
+    # Use a subset of phases
+    harness.load_protocol(GRASP_PROTOCOL, phases=["pre_grasp", "grasp", "lift"])
+
+    # Define a custom protocol
+    my_protocol = TaskProtocol(
+        name="assembly",
+        description="Multi-step assembly task",
+        phases=[
+            TaskPhase("pick", "Pick up the part"),
+            TaskPhase("align", "Align part with target"),
+            TaskPhase("insert", "Insert part into slot"),
+        ],
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TaskPhase:
+    """A single semantic phase in a task protocol.
+
+    Attributes:
+        name: Short identifier (used as checkpoint name).
+        description: Human-readable description of what happens in this phase.
+        cameras: Camera names to capture at this phase. Defaults to ["front"].
+        metadata: Arbitrary metadata for this phase (e.g. expected duration, tolerances).
+    """
+
+    name: str
+    description: str = ""
+    cameras: list[str] = field(default_factory=lambda: ["front"])
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TaskProtocol:
+    """A semantic protocol defining the phases of a robot task.
+
+    A TaskProtocol is a reusable template that describes the natural stages
+    of a task type. Loading a protocol into a Harness automatically registers
+    the appropriate checkpoints with their camera configurations.
+
+    Attributes:
+        name: Protocol identifier (e.g. "grasp", "locomotion").
+        description: Human-readable description of the task type.
+        phases: Ordered list of semantic phases.
+    """
+
+    name: str
+    description: str = ""
+    phases: list[TaskPhase] = field(default_factory=list)
+
+    def phase_names(self) -> list[str]:
+        """Return ordered list of phase names."""
+        return [p.name for p in self.phases]
+
+    def get_phase(self, name: str) -> TaskPhase:
+        """Look up a phase by name. Raises KeyError if not found."""
+        for phase in self.phases:
+            if phase.name == name:
+                return phase
+        raise KeyError(
+            f"Phase '{name}' not in protocol '{self.name}'. Available: {self.phase_names()}"
+        )
+
+    def select(self, phase_names: list[str]) -> TaskProtocol:
+        """Return a new protocol containing only the specified phases (in order).
+
+        Raises KeyError if any name is not in this protocol.
+        """
+        selected = []
+        for name in phase_names:
+            selected.append(self.get_phase(name))
+        return TaskProtocol(
+            name=self.name,
+            description=self.description,
+            phases=selected,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Built-in protocols
+# ---------------------------------------------------------------------------
+
+GRASP_PROTOCOL = TaskProtocol(
+    name="grasp",
+    description="Pick-and-place grasping task",
+    phases=[
+        TaskPhase("plan", "Plan grasp trajectory and visualize target path"),
+        TaskPhase("pre_grasp", "Move to pre-grasp pose above the object"),
+        TaskPhase("approach", "Approach the object along the planned path"),
+        TaskPhase("grasp", "Close gripper on the object"),
+        TaskPhase("lift", "Lift the grasped object"),
+        TaskPhase("place", "Place the object at the target location"),
+        TaskPhase("home", "Return to home position"),
+    ],
+)
+
+LOCOMOTION_PROTOCOL = TaskProtocol(
+    name="locomotion",
+    description="Legged locomotion task",
+    phases=[
+        TaskPhase("initial", "Initial standing pose"),
+        TaskPhase("accelerate", "Accelerate to target velocity"),
+        TaskPhase("steady", "Steady-state locomotion"),
+        TaskPhase("decelerate", "Decelerate to stop"),
+        TaskPhase("terminal", "Final standing pose"),
+    ],
+)
+
+LOCO_MANIPULATION_PROTOCOL = TaskProtocol(
+    name="loco_manipulation",
+    description="Mobile manipulation — locomotion combined with grasping",
+    phases=[
+        # Navigation
+        TaskPhase("navigate", "Walk to the target object area"),
+        # Manipulation
+        TaskPhase("pre_grasp", "Position arm for grasping"),
+        TaskPhase("grasp", "Grasp the object"),
+        # Transport
+        TaskPhase("transport", "Walk while holding the object"),
+        # Placement
+        TaskPhase("place", "Place the object at the destination"),
+        TaskPhase("retreat", "Step back and return to ready pose"),
+    ],
+)
+
+DANCE_PROTOCOL = TaskProtocol(
+    name="dance",
+    description="Rhythmic motion / dance routine",
+    phases=[
+        TaskPhase("ready", "Initial ready pose"),
+        TaskPhase("sequence", "Main dance sequence"),
+        TaskPhase("finale", "Final pose"),
+    ],
+)
+
+# Registry of all built-in protocols for discovery
+BUILTIN_PROTOCOLS: dict[str, TaskProtocol] = {
+    p.name: p
+    for p in [GRASP_PROTOCOL, LOCOMOTION_PROTOCOL, LOCO_MANIPULATION_PROTOCOL, DANCE_PROTOCOL]
+}

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,298 @@
+"""Tests for semantic task protocols."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from roboharness.core.capture import CameraView
+from roboharness.core.harness import Harness
+from roboharness.core.protocol import (
+    BUILTIN_PROTOCOLS,
+    DANCE_PROTOCOL,
+    GRASP_PROTOCOL,
+    LOCO_MANIPULATION_PROTOCOL,
+    LOCOMOTION_PROTOCOL,
+    TaskPhase,
+    TaskProtocol,
+)
+
+# ---------------------------------------------------------------------------
+# Mock backend (reused from test_harness.py pattern)
+# ---------------------------------------------------------------------------
+
+
+class MockBackend:
+    def __init__(self) -> None:
+        self._time = 0.0
+        self._state: dict[str, Any] = {"qpos": [0.0], "qvel": [0.0]}
+
+    def step(self, action: Any) -> dict[str, Any]:
+        self._time += 0.01
+        self._state["qpos"] = [self._state["qpos"][0] + 0.1]
+        return self.get_state()
+
+    def get_state(self) -> dict[str, Any]:
+        return {**self._state, "time": self._time}
+
+    def save_state(self) -> dict[str, Any]:
+        return {"state": {**self._state}, "time": self._time}
+
+    def restore_state(self, state: dict[str, Any]) -> None:
+        self._state = {**state["state"]}
+        self._time = state["time"]
+
+    def capture_camera(self, camera_name: str) -> CameraView:
+        return CameraView(name=camera_name, rgb=np.zeros((64, 64, 3), dtype=np.uint8))
+
+    def get_sim_time(self) -> float:
+        return self._time
+
+    def reset(self) -> dict[str, Any]:
+        self._time = 0.0
+        self._state = {"qpos": [0.0], "qvel": [0.0]}
+        return self.get_state()
+
+
+# ---------------------------------------------------------------------------
+# TaskPhase tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaskPhase:
+    def test_basic_creation(self):
+        phase = TaskPhase("grasp", "Close gripper on object")
+        assert phase.name == "grasp"
+        assert phase.description == "Close gripper on object"
+        assert phase.cameras == ["front"]
+        assert phase.metadata == {}
+
+    def test_custom_cameras(self):
+        phase = TaskPhase("lift", "Lift object", cameras=["front", "wrist", "top"])
+        assert phase.cameras == ["front", "wrist", "top"]
+
+    def test_metadata(self):
+        phase = TaskPhase("approach", "Approach object", metadata={"speed": 0.1})
+        assert phase.metadata["speed"] == 0.1
+
+    def test_frozen(self):
+        phase = TaskPhase("grasp", "Close gripper")
+        with pytest.raises(AttributeError):
+            phase.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# TaskProtocol tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaskProtocol:
+    def test_basic_creation(self):
+        protocol = TaskProtocol(
+            name="test",
+            description="Test protocol",
+            phases=[
+                TaskPhase("a", "Phase A"),
+                TaskPhase("b", "Phase B"),
+            ],
+        )
+        assert protocol.name == "test"
+        assert len(protocol.phases) == 2
+
+    def test_phase_names(self):
+        protocol = TaskProtocol(
+            name="test",
+            phases=[TaskPhase("x"), TaskPhase("y"), TaskPhase("z")],
+        )
+        assert protocol.phase_names() == ["x", "y", "z"]
+
+    def test_get_phase(self):
+        phase_b = TaskPhase("b", "Phase B")
+        protocol = TaskProtocol(
+            name="test",
+            phases=[TaskPhase("a", "Phase A"), phase_b],
+        )
+        assert protocol.get_phase("b") == phase_b
+
+    def test_get_phase_missing_raises(self):
+        protocol = TaskProtocol(name="test", phases=[TaskPhase("a")])
+        with pytest.raises(KeyError, match="not_here"):
+            protocol.get_phase("not_here")
+
+    def test_select_subset(self):
+        protocol = TaskProtocol(
+            name="full",
+            description="Full protocol",
+            phases=[
+                TaskPhase("a"),
+                TaskPhase("b"),
+                TaskPhase("c"),
+                TaskPhase("d"),
+            ],
+        )
+        subset = protocol.select(["b", "d"])
+        assert subset.phase_names() == ["b", "d"]
+        assert subset.name == "full"
+        assert subset.description == "Full protocol"
+
+    def test_select_preserves_order(self):
+        protocol = TaskProtocol(
+            name="ordered",
+            phases=[TaskPhase("a"), TaskPhase("b"), TaskPhase("c")],
+        )
+        # Request in different order than defined — result follows request order
+        subset = protocol.select(["c", "a"])
+        assert subset.phase_names() == ["c", "a"]
+
+    def test_select_missing_raises(self):
+        protocol = TaskProtocol(name="test", phases=[TaskPhase("a")])
+        with pytest.raises(KeyError, match="missing"):
+            protocol.select(["a", "missing"])
+
+    def test_empty_protocol(self):
+        protocol = TaskProtocol(name="empty")
+        assert protocol.phase_names() == []
+        assert protocol.phases == []
+
+    def test_frozen(self):
+        protocol = TaskProtocol(name="test")
+        with pytest.raises(AttributeError):
+            protocol.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Built-in protocols
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinProtocols:
+    def test_grasp_protocol(self):
+        assert GRASP_PROTOCOL.name == "grasp"
+        names = GRASP_PROTOCOL.phase_names()
+        assert "pre_grasp" in names
+        assert "grasp" in names
+        assert "lift" in names
+        assert "plan" in names
+        assert "place" in names
+        assert "home" in names
+        assert len(names) == 7
+
+    def test_locomotion_protocol(self):
+        assert LOCOMOTION_PROTOCOL.name == "locomotion"
+        names = LOCOMOTION_PROTOCOL.phase_names()
+        assert "initial" in names
+        assert "steady" in names
+        assert "terminal" in names
+        assert len(names) == 5
+
+    def test_loco_manipulation_protocol(self):
+        assert LOCO_MANIPULATION_PROTOCOL.name == "loco_manipulation"
+        names = LOCO_MANIPULATION_PROTOCOL.phase_names()
+        assert "navigate" in names
+        assert "grasp" in names
+        assert "transport" in names
+        assert "place" in names
+        assert len(names) == 6
+
+    def test_dance_protocol(self):
+        assert DANCE_PROTOCOL.name == "dance"
+        assert len(DANCE_PROTOCOL.phases) == 3
+
+    def test_builtin_registry(self):
+        assert set(BUILTIN_PROTOCOLS.keys()) == {
+            "grasp",
+            "locomotion",
+            "loco_manipulation",
+            "dance",
+        }
+        for name, proto in BUILTIN_PROTOCOLS.items():
+            assert proto.name == name
+            assert len(proto.phases) > 0
+
+    def test_all_builtin_phases_have_descriptions(self):
+        for proto in BUILTIN_PROTOCOLS.values():
+            for phase in proto.phases:
+                assert phase.description, f"{proto.name}.{phase.name} has no description"
+
+
+# ---------------------------------------------------------------------------
+# Harness integration: load_protocol
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessLoadProtocol:
+    def test_load_protocol_adds_checkpoints(self, tmp_path):
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(GRASP_PROTOCOL)
+        assert harness.list_checkpoints() == GRASP_PROTOCOL.phase_names()
+
+    def test_load_protocol_with_phase_subset(self, tmp_path):
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(GRASP_PROTOCOL, phases=["pre_grasp", "grasp", "lift"])
+        assert harness.list_checkpoints() == ["pre_grasp", "grasp", "lift"]
+
+    def test_load_protocol_respects_cameras(self, tmp_path):
+        protocol = TaskProtocol(
+            name="cam_test",
+            phases=[
+                TaskPhase("a", cameras=["front", "wrist"]),
+                TaskPhase("b", cameras=["top"]),
+            ],
+        )
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(protocol)
+
+        # Verify cameras are correctly passed through
+        assert harness._checkpoints[0].cameras == ["front", "wrist"]
+        assert harness._checkpoints[1].cameras == ["top"]
+
+    def test_load_protocol_sets_active_protocol(self, tmp_path):
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        assert harness.active_protocol is None
+        harness.load_protocol(GRASP_PROTOCOL)
+        assert harness.active_protocol is not None
+        assert harness.active_protocol.name == "grasp"
+
+    def test_load_protocol_subset_stores_subset(self, tmp_path):
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(GRASP_PROTOCOL, phases=["grasp", "lift"])
+        assert harness.active_protocol is not None
+        assert harness.active_protocol.phase_names() == ["grasp", "lift"]
+
+    def test_load_protocol_clears_previous_checkpoints(self, tmp_path):
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.add_checkpoint("old_cp")
+        harness.load_protocol(GRASP_PROTOCOL, phases=["grasp"])
+        assert harness.list_checkpoints() == ["grasp"]
+
+    def test_load_protocol_end_to_end(self, tmp_path):
+        """Full workflow: load protocol, reset, run through phases."""
+        protocol = TaskProtocol(
+            name="mini",
+            phases=[TaskPhase("step_a"), TaskPhase("step_b")],
+        )
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(protocol)
+        harness.reset()
+
+        result_a = harness.run_to_next_checkpoint([None] * 5)
+        assert result_a is not None
+        assert result_a.checkpoint_name == "step_a"
+
+        result_b = harness.run_to_next_checkpoint([None] * 5)
+        assert result_b is not None
+        assert result_b.checkpoint_name == "step_b"
+
+        # No more checkpoints
+        assert harness.run_to_next_checkpoint([None]) is None
+
+    def test_load_protocol_phase_metadata_in_checkpoint(self, tmp_path):
+        protocol = TaskProtocol(
+            name="meta_test",
+            phases=[TaskPhase("x", metadata={"timeout": 10})],
+        )
+        harness = Harness(MockBackend(), output_dir=tmp_path)
+        harness.load_protocol(protocol)
+        assert harness._checkpoints[0].metadata == {"timeout": 10}


### PR DESCRIPTION
Instead of capturing at arbitrary simulation step counts, TaskProtocol
defines semantically meaningful phases (e.g. pre_grasp, approach, grasp,
lift) that map to the natural structure of a robot task.

Adds:
- TaskPhase/TaskProtocol dataclasses in core/protocol.py
- Built-in protocols: GRASP, LOCOMOTION, LOCO_MANIPULATION, DANCE
- Harness.load_protocol() to register phases as checkpoints
- BUILTIN_PROTOCOLS registry for discovery
- 27 tests covering protocol logic and harness integration

https://claude.ai/code/session_01AJFYybiJGZkDkFBQ5P8vXH