### PR TITLE
fix(ci): ensure landing page deploys even when demo examples fail

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,10 +60,14 @@ jobs:
           MUJOCO_GL: osmesa
         run: python examples/lerobot_g1_native.py --report --output-dir ./harness_output
 
-      - name: Build Pages site
+      - name: Build static pages (landing + SONIC)
         run: |
-          mkdir -p _site
+          mkdir -p _site _site/sonic
+          cp .github/pages/index.html _site/index.html
+          cp .github/pages/sonic.html _site/sonic/index.html
 
+      - name: Build demo reports
+        run: |
           # --- Demo 1: Simple Grasp (with Meshcat 3D) ---
           mkdir -p _site/grasp
           cp harness_output/report.html _site/grasp/index.html
@@ -112,20 +116,15 @@ jobs:
             cp "${cp_dir}"state.json "_site/g1-native/${cp_name}/" 2>/dev/null || true
           done
 
-          # --- Demo 5: SONIC Motion Tracking (static page, requires GPU) ---
-          mkdir -p _site/sonic
-          cp .github/pages/sonic.html _site/sonic/index.html
-
-          # --- Landing page ---
-          cp .github/pages/index.html _site/index.html
-
       - name: Upload Pages artifact
+        if: always()
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
 
   deploy:
     needs: build
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
The Build Pages site step had the landing page copy at the very end of
a single shell script. With set -e (GitHub Actions default), if any
lerobot example failed to produce a report, the cp would fail and abort
the script before reaching the landing page copy — leaving the deployed
site stuck on the old 2-card inline HTML.

Fix:
- Split into two steps: "Build static pages" (landing + SONIC) runs
  first and always succeeds since it only copies checked-in files
- "Build demo reports" handles generated content separately
- Upload artifact with if: always() so static pages deploy even when
  demo report copies fail
- Deploy job uses if: !cancelled() so it runs when build partially fails

https://claude.ai/code/session_01SVTnTNfife3vYgu79tfee5