### PR TITLE
fix(ci): correct grasp report filename in Pages build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # --- Demo 1: Simple Grasp (with Meshcat 3D) ---
           mkdir -p _site/grasp
-          cp harness_output/report.html _site/grasp/index.html
+          cp harness_output/mujoco_grasp_report.html _site/grasp/index.html
           for cp_dir in harness_output/mujoco_grasp/trial_001/*/; do
             cp_name=$(basename "$cp_dir")
             mkdir -p "_site/grasp/${cp_name}"


### PR DESCRIPTION
After the reporting refactor (bd1f481), mujoco_grasp.py generates `mujoco_grasp_report.html` via shared reporting.py, but pages.yml still referenced the old name `report.html`. This cp failure (first command in "Build demo reports" with set -e) blocked ALL demo copies — even the correctly-named g1-reach, g1-loco, and g1-native reports.

https://claude.ai/code/session_01SVTnTNfife3vYgu79tfee5