### PR TITLE
fix(ci): revert SONIC example step that breaks Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,15 +60,11 @@ jobs:
           MUJOCO_GL: osmesa
         run: python examples/lerobot_g1_native.py --report --output-dir ./harness_output
 
-      - name: Run SONIC locomotion example
-        env:
-          MUJOCO_GL: osmesa
-        run: python examples/sonic_locomotion.py --report --output-dir ./harness_output
-
-      - name: Build static pages (landing)
+      - name: Build static pages (landing + SONIC)
         run: |
-          mkdir -p _site
+          mkdir -p _site _site/sonic
           cp .github/pages/index.html _site/index.html
+          cp .github/pages/sonic.html _site/sonic/index.html
 
       - name: Build demo reports
         run: |
@@ -118,17 +114,6 @@ jobs:
             cp "${cp_dir}"*_rgb.png "_site/g1-native/${cp_name}/" 2>/dev/null || true
             cp "${cp_dir}"metadata.json "_site/g1-native/${cp_name}/" 2>/dev/null || true
             cp "${cp_dir}"state.json "_site/g1-native/${cp_name}/" 2>/dev/null || true
-          done
-
-          # --- Demo 5: SONIC Locomotion ---
-          mkdir -p _site/sonic
-          cp harness_output/sonic_locomotion_report.html _site/sonic/index.html
-          for cp_dir in harness_output/sonic_locomotion/trial_001/*/; do
-            cp_name=$(basename "$cp_dir")
-            mkdir -p "_site/sonic/${cp_name}"
-            cp "${cp_dir}"*_rgb.png "_site/sonic/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"metadata.json "_site/sonic/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"state.json "_site/sonic/${cp_name}/" 2>/dev/null || true
           done
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

- **Critical fix**: The "Run SONIC locomotion example" step added in #131 crashes because `nvidia/GEAR-SONIC` on HuggingFace doesn't have the expected ONNX files (`encoder_sonic.onnx` returns 404). This failure blocks the **entire** build job, meaning no demos get deployed at all — runs #94, #95, #96 have all been failing.
- Reverts to the static `sonic.html` documentation page until the upstream ONNX models are published.
- Restores the `Build static pages (landing + SONIC)` step that copies both `index.html` and `sonic.html`.

## Root cause

```
huggingface_hub.errors.RemoteEntryNotFoundError: 404 Client Error.
Entry Not Found for url: https://huggingface.co/nvidia/GEAR-SONIC/resolve/main/encoder_sonic.onnx
```

The `SonicLocomotionController()` constructor downloads 3 ONNX models. The planner model exists but encoder/decoder don't, causing a crash before any simulation runs.

## Test plan

- [ ] Pages deployment succeeds (currently broken for all 5 demos)
- [ ] All demo pages load correctly at https://miaodx.com/roboharness/
- [ ] SONIC page shows static documentation (as before)

https://claude.ai/code/session_01SVTnTNfife3vYgu79tfee5