### PR TITLE
docs: add Q2+ project roadmap and ecosystem strategy

### DIFF
--- a/docs/ecosystem-strategy.md
+++ b/docs/ecosystem-strategy.md
@@ -1,0 +1,302 @@
+# Ecosystem & Community Strategy
+
+_Last updated: April 10, 2026_
+_This document covers everything outside the project itself: making roboharness discoverable, building technical influence, entering key communities._
+_Technical roadmap is in `roadmap-2026-q2.md`._
+
+---
+
+## Core Thesis
+
+Roboharness's biggest bottleneck is not technical capability — it's **discoverability**. The project occupies a position no one else holds (AI coding agent + visual regression testing + robot simulation), but if no one knows that position exists, larger players' tools will cover it within 6–12 months.
+
+This strategy's goal: **make roboharness synonymous with "harness engineering for robotics"** before larger companies react.
+
+---
+
+## Content Strategy: Define the Category
+
+### Article 1: Harness Engineering for Robotics (Category-Defining Piece)
+
+**Why this must be written:** Searched every harness engineering resource — 92+ articles, projects, and papers. All target software development. Not a single one discusses robotics. Writing the first one = defining the category.
+
+**Angle:** Not "here's roboharness," but "when AI agents start writing robot code, what kind of harness do we need?" Roboharness is one answer, but the article's value is in raising the question itself.
+
+**Publication plan:**
+
+- Chinese version first on WeChat (riding the Harness Engineering hype wave)
+- English version on Medium / dev.to / HuggingFace blog, simultaneously submit to Hacker News
+- English title suggestion: "Harness Engineering for Robotics: Why AI Coding Agents Need Eyes to Debug Robots"
+
+**Key content points:**
+
+1. How the three dimensions of software harness engineering (time/space/interaction) change in robotics
+2. Robotics-specific challenge: physical behavior can't be textualized — screenshots are the lowest-cost feedback channel
+3. Academic validation: FAEA / CaP-X
+4. Concrete demo: how roboharness lets Claude Code see what the G1 is doing
+5. Open questions: Is VLM judge accuracy sufficient? How to choose checkpoint granularity?
+
+**⚡ Action items:**
+
+- [ ] Refine Chinese draft (already exists in project files), add ROS perspective and LeRobot evaluation gap evidence
+- [ ] Include showcase Live Report links + GitHub link at the end
+- [ ] After publishing, tag relevant authors on Twitter/X to spark discussion
+
+### Article 2: Technical Blog Post (already in blog/ directory)
+
+Draft exists: "Why AI Coding Agents Don't Need a Separate VLM for Robot Debugging." More technical, published as a companion to the category piece.
+
+**⚡ Action items:**
+
+- [ ] Finalize `blog/why-ai-coding-agents-dont-need-a-separate-vlm-for-robot-debugging.md`
+- [ ] Publish English version on Medium, tags: robotics, ai-agents, simulation, harness-engineering
+
+### Ongoing Content
+
+For each new showcase integration (GR00T, Pi0, etc.), publish a short post + GIF + Live Report link. Fixed format:
+
+```
+Problem → How roboharness solves it → One command to reproduce → Live Report screenshot
+```
+
+---
+
+## ROS Community Penetration
+
+### Why the ROS Community Matters
+
+ROS is the de facto standard for robot development. ros-mcp-server already has 931 stars, showing strong ROS community interest in "LLM + robotics." But ROS tooling is C++/Python mixed, CI uses colcon + Industrial CI, evaluation uses rostest/launch_testing. **There is no AI agent-friendly visual testing tool in the ROS ecosystem.**
+
+### ⚡ Action Items
+
+**1. Post on ROS Discourse**
+
+- [ ] Go to https://discourse.ros.org/, post in the "General" category
+- Title: `Visual testing harness for AI coding agents in robot simulation — looking for feedback`
+- Content outline:
+  - Opening: How do you debug simulation behavior when using Claude Code / Codex for robotics development?
+  - Middle: Show MuJoCo grasp demo GIF + Live Report link (https://miaodx.com/roboharness/grasp/)
+  - Closing: GitHub link, explicitly state "looking for feedback, not promoting"
+- This is a genuine question + an existing attempt, not a sales pitch
+
+**2. Submit to awesome-ros2**
+
+- [ ] Fork https://github.com/fkromer/awesome-ros2
+- [ ] Add one line under `Packages` > `Testing` or `Simulation`:
+  ```
+  - [roboharness](https://github.com/MiaoDX/roboharness) - Visual testing harness for AI coding agents in robot simulation. Checkpoint screenshots + structured JSON for Claude Code / Codex to see and judge robot behavior.
+  ```
+- [ ] Submit PR titled: `Add roboharness — visual testing for AI coding agents in robot simulation`
+
+**3. ros2_mcp Collaboration**
+
+- [ ] Open a discussion or issue at https://github.com/LCAS/ros2_mcp
+- Title: `Integration idea: roboharness for checkpoint-based visual testing alongside ros2_mcp real-time interaction`
+- Content: ros2_mcp handles real-time ROS topic interaction, roboharness MCP handles checkpoint-based visual testing. Complementary, not competing. Link to roboharness MCP server docs.
+- Goal: Establish connection, not request merging
+
+**4. Gazebo Showcase (later)**
+
+- [ ] Create `ros2-gazebo/` directory in `roboharness/showcase`
+- Capture Gazebo rendered images via ROS topic + get state via TF
+- This is the easiest entry point for ROS users
+
+---
+
+## HuggingFace Ecosystem
+
+### ⚡ Action Items
+
+**1. LeRobot Upstream Discussion Contributions**
+
+- [ ] Comment on https://github.com/huggingface/lerobot/issues/538 (headless eval) — explain that roboharness already solves headless screenshot capture, include link and code example
+- [ ] Comment on https://github.com/huggingface/lerobot/issues/2375 (eval reproducibility) — propose checkpoint screenshots + structured JSON as a diagnostic approach
+- [ ] Do not sell — provide concrete technical solutions and code snippets, let others judge the value
+
+**2. HuggingFace Space Demo**
+
+- [ ] Create HuggingFace Space: `MiaoDX/roboharness-demo`
+- [ ] Type: "Static HTML" — no GPU needed, just host CI-generated HTML reports
+- [ ] Content: All 5 demo Live Reports (grasp, g1-reach, g1-loco, g1-native, sonic)
+- [ ] Space description: project overview + GitHub link
+
+**3. LeRobot Plugin (after eval plugin ships)**
+
+- [ ] If LeRobot plugin system supports `pip install lerobot-plugin-roboharness`, publish one
+- [ ] Otherwise, ship as standalone `roboharness[lerobot]`
+
+---
+
+## Academic Community
+
+### ⚡ Action Items
+
+**1. Conferences**
+
+- [ ] Check ICRA 2026 (June 19-25, Vienna) workshop list for "AI for Robot Development" or "Simulation Testing" topics. If relevant, submit a demo paper
+- [ ] Check CoRL 2026 submission deadline, evaluate whether to submit a system paper
+- [ ] Monitor NeurIPS 2026 workshop CFPs (typically announced September)
+
+**2. Citation Network**
+
+- [ ] Add a "Related Work" or "See Also" section to README citing: FAEA (arXiv:2601.20334), CaP-X (arXiv:2603.22435), StepEval (arXiv:2509.19524), SOLE-R1 (arXiv:2603.28730), AOR (arXiv:2603.04466)
+- [ ] Cite these works in the category-defining article — cited authors will notice
+- [ ] If the showcase includes a CaP-X comparison demo, email the CaP-X first author to discuss complementarity
+
+---
+
+## GitHub Strategy
+
+### Org Structure
+
+`github.com/roboharness` org exists, currently empty. Planned structure:
+
+```
+roboharness/              (GitHub org, exists)
+├── showcase              (integration demo repo, to be created)
+├── .github               (org-level profile README, to be created)
+└── roboharness.github.io (later, if a standalone site is needed)
+```
+
+MiaoDX/roboharness remains the core repo's primary location. Reason: existing stars, forks, PyPI links, CI config are all there. Consider transfer to org only when the project scales (5+ external contributors).
+
+### ⚡ Action Items
+
+**1. Org Profile README**
+
+- [ ] Create `.github` repo under `roboharness` org
+- [ ] Write `profile/README.md`:
+
+```markdown
+# roboharness
+
+**Harness Engineering for Robotics** — visual testing infrastructure for AI coding agents in robot simulation.
+
+| Repo | Description |
+|------|-------------|
+| [MiaoDX/roboharness](https://github.com/MiaoDX/roboharness) | Core library — checkpoint screenshots + structured JSON for Claude Code / Codex |
+| [roboharness/showcase](https://github.com/roboharness/showcase) | Integration demos — GR00T, Pi0, LeRobot, SONIC, Isaac Lab |
+
+📄 [Live Visual Reports](https://miaodx.com/roboharness/) · 📦 [PyPI](https://pypi.org/project/roboharness/)
+```
+
+**2. Showcase Repo Initialization**
+
+- [ ] Create `roboharness/showcase` repo
+- [ ] Initialize skeleton: README + directory structure (see `roadmap-2026-q2.md`)
+- [ ] First showcase: extract `examples/lerobot_g1_native.py` as a standalone runnable showcase
+- [ ] Each showcase directory contains: README.md, requirements.txt, run.sh, main script
+- [ ] CI matrix: one independent job per showcase
+
+**3. Submit to awesome-harness-engineering**
+
+- [ ] Fork https://github.com/walkinglabs/awesome-harness-engineering
+- [ ] Find appropriate category (likely "Tools" or create a new "Robotics" category), add:
+  ```
+  - [roboharness](https://github.com/MiaoDX/roboharness) - Visual testing harness for AI coding agents in robot simulation. The first harness engineering tool for robotics.
+  ```
+- [ ] Submit PR
+
+**4. Submit to harn.app**
+
+- [ ] Go to https://harn.app, find submission method (usually GitHub issue or form)
+- [ ] Submit roboharness, categorize as "Testing / Evaluation"
+- [ ] Emphasize: the only harness engineering tool targeting robotics
+
+---
+
+## Funding & Accelerators
+
+### ⚡ Action Items
+
+**Anthropic Claude for Open Source (deadline June 30, 2026)**
+
+- [ ] Check application at https://www.anthropic.com/open-source
+- [ ] Application talking points:
+  - Positioning: AI agent testing infrastructure for robotics
+  - Core narrative: roboharness has 96% commits by Claude Code — the project is itself proof of Claude's capability
+  - Apply via critical infrastructure exception path (star count insufficient but qualifies as critical infrastructure)
+- [ ] Apply immediately, don't wait for star growth
+
+**Robotics Factory Accelerate (deadline July 18, 2026)**
+
+- [ ] Check requirements at https://www.roboticsfactory.org/accelerate
+- [ ] Evaluate fit (leans toward company-building, not pure open source)
+- [ ] If aligned, prepare application
+
+**Google DeepMind Accelerator: Robotics**
+
+- [ ] Monitor https://deepmind.google/models/gemini-robotics/accelerator/ for future cohort announcements
+- [ ] If it opens to Asia or globally, apply immediately
+
+**Long-term**
+
+- [ ] Q4 2026: Prepare GSoC 2027 org application materials (project ideas list, contributor guide)
+- [ ] End of Q2 2026: Evaluate NumFOCUS affiliated project application feasibility
+
+---
+
+## Collaborations & Positioning
+
+### Relationship Map
+
+| Project | Relationship | Concrete Action |
+|---------|-------------|-----------------|
+| LeRobot | Complementary: they train & deploy, we test | Comment on #538 and #2375; ship eval plugin; HF Space demo |
+| CaP-X | Complementary: they synthesize policies, we test them | Showcase comparison demo; contact first author |
+| ros-mcp-server / ros2_mcp | Complementary: real-time control vs checkpoint testing | Open discussion on ros2_mcp |
+| Isaac Lab-Arena | Complementary: large-scale benchmarks vs visual debugging | Showcase integration |
+| rl_sar | Complementary: sim-to-real deployment vs simulation testing | Potential robowbc collaboration |
+| mujoco-mcp | Highest overlap | Differentiate: testing vs interaction |
+
+### Relationship with Large Companies
+
+- **NVIDIA**: roboharness supports GR00T + SONIC + Isaac Lab full stack. After showcase ships, contact NVIDIA DevRel for official documentation reference
+- **HuggingFace**: LeRobot plugin + Space demo. After shipping, tag LeRobot team members
+- **Anthropic**: Claude for Open Source application + roboharness as Claude Code best-practice showcase
+
+---
+
+## Metrics
+
+How to know if the strategy is working:
+
+**Short-term signals (weeks):**
+- ROS Discourse post views and replies
+- awesome-harness-engineering PR merged or not
+- harn.app listing status
+- HuggingFace Space visit count
+
+**Medium-term signals (months):**
+- GitHub star growth rate
+- Whether LeRobot community members mention roboharness in discussions
+- External contributors submitting PRs
+- Showcase repo usage
+
+**Long-term signals:**
+- Cited in academic papers
+- Referenced in NVIDIA / HuggingFace official documentation
+- Mentioned as a default recommendation in "AI + Robotics" discussions
+
+---
+
+## Action Summary
+
+Ordered by immediate executability. Tagged by executor:
+
+| # | Action | Executor | Dependencies |
+|---|--------|----------|-------------|
+| 1 | Create `.github` repo in `roboharness` org + org profile README | Claude Code | Org exists ✅ |
+| 2 | Create `roboharness/showcase` repo + skeleton | Claude Code | #1 |
+| 3 | Add Related Work section to README (FAEA/CaP-X/StepEval/SOLE-R1/AOR) | Claude Code | None |
+| 4 | Submit PR to awesome-harness-engineering | Claude Code | None |
+| 5 | Submit PR to awesome-ros2 | Claude Code | None |
+| 6 | Create HuggingFace Space (Static HTML, host 5 demo reports) | Claude Code | None |
+| 7 | Apply for Anthropic Claude for Open Source | Human | None |
+| 8 | Comment on LeRobot #538 and #2375 with roboharness solutions + code examples | Human | None |
+| 9 | Submit to harn.app | Human | Check submission method |
+| 10 | Finalize and publish category-defining article (Chinese, WeChat) | Human + Claude | Draft exists |
+| 11 | Post on ROS Discourse seeking feedback | Human | None |
+| 12 | Open discussion on ros2_mcp about collaboration | Human | None |
+| 13 | Publish English article on Medium + submit to Hacker News | Human | After #10 |
+| 14 | Check ICRA 2026 workshop list, evaluate demo paper feasibility | Human | None |

--- a/docs/roadmap-2026-q2.md
+++ b/docs/roadmap-2026-q2.md
@@ -1,0 +1,193 @@
+# Roboharness Project Roadmap — 2026 Q2+
+
+_Last updated: April 10, 2026_
+_This document covers the project's technical direction and priority ordering. Community and distribution strategy is in `ecosystem-strategy.md`._
+_No timing estimates — priorities determine what to work on, AI coding agents determine how fast it ships._
+
+---
+
+## Current State
+
+v0.1.1 on PyPI. Core capabilities:
+
+- Checkpoint multi-view screenshots + structured JSON
+- MuJoCo + Meshcat backend
+- Gymnasium wrapper (zero-change integration for Isaac Lab, ManiSkill)
+- CLI (inspect / report)
+- Rerun integration
+- LeRobot G1 locomotion (wrapper mode + native `make_env` mode)
+- SONIC locomotion controller (planner + tracking modes)
+- G1 WBC reach (Pinocchio + Pink)
+- MCP server + tools (#70)
+- CI: CPU lint/type/test + GPU smoke test (Cirun/GCP)
+- GitHub Pages auto-generated HTML visual reports
+
+---
+
+## Priority Framework
+
+Each direction is evaluated against two criteria:
+
+1. **Does it help acquire users?** — Makes new users discover and use roboharness
+2. **Does it help build technical influence?** — Makes roboharness cited and discussed at the AI + Robotics intersection
+
+Directions are split into "do now" and "do later." "Do now" means the next available agent session should pick this up.
+
+---
+
+## Do Now
+
+### A. LeRobot Evaluation Plugin
+
+**Why highest priority:** LeRobot has 22,000+ stars, an ICLR 2026 paper, and is the de facto standard in the robot learning community. Its evaluation infrastructure has clear gaps:
+
+- No headless visual evaluation (issue #538)
+- Evaluation script uses fixed initial states (issue #2375)
+- Multiple issues report inability to reproduce benchmark results with no diagnostic tooling (#2354, #1507, #2259)
+- No CI gate, no pass/fail thresholds, no regression detection between policy versions
+
+**What to do:**
+
+1. Create `roboharness[lerobot]` optional dependency
+2. Wrap `lerobot-eval` output, insert checkpoint screenshots at key steps
+3. Produce structured JSON (per-episode success, per-step screenshot paths, key metrics)
+4. Provide CI-friendly pass/fail gate (e.g., success rate < threshold → exit 1)
+5. Ship a LeRobot-compatible example: `pip install roboharness[lerobot] && python examples/lerobot_eval_harness.py`
+
+**Exit criteria:** A LeRobot user can run one command to get visual regression testing in CI.
+
+**Related issues:** New issue needed. Extends #83 (native LeRobot integration).
+
+### B. Constraint Evaluator
+
+**Why:** Upgrading from "can see" to "can judge" is the core value leap. The `evaluate/` module has code but no end-to-end demo yet.
+
+**What to do:**
+
+1. Complete the YAML constraint → pass/fail flow described in `docs/p1-constraint-evaluator.md`
+2. Demo constraint evaluation on mujoco_grasp and g1_wbc_reach
+3. Add pass/fail markers (green/red) to HTML reports
+4. Provide `roboharness evaluate --constraints grasp_default.yaml` CLI path
+
+**Exit criteria:** CI-generated HTML reports show which checkpoints passed constraints and which failed.
+
+**Related issues:** `docs/p1-constraint-evaluator.md` has the design doc.
+
+### C. Showcase Repository (github.com/roboharness/showcase)
+
+**Why:** GR00T N1.6, Pi0, LeRobot, SONIC, etc. need to demonstrate roboharness integration, but embedding them in the core repo would bloat it and explode dependencies.
+
+**Structure:**
+
+```
+roboharness/showcase/
+├── README.md                     # Overview + run instructions
+├── groot-n16/
+│   ├── README.md
+│   ├── requirements.txt          # groot deps + roboharness
+│   ├── run.sh                    # one-command demo
+│   ├── harness_config.yaml       # checkpoint definitions
+│   └── groot_visual_test.py      # thin wrapper, not a submodule
+├── pi0-libero/
+│   ├── README.md
+│   ├── requirements.txt
+│   ├── run.sh
+│   └── pi0_eval_harness.py
+├── lerobot-g1/
+│   └── ...
+├── sonic-locomotion/
+│   └── ...
+├── capx-comparison/              # Comparison demo with CaP-X
+│   └── ...
+└── .github/
+    └── workflows/
+        └── showcase-ci.yml       # Each showcase is an independent CI job
+```
+
+**Key design decisions:**
+
+- **No git submodules**: Use requirements.txt + runtime pip install to pull dependencies. Avoids submodule hell.
+- **Each showcase is self-contained**: `cd showcase/groot-n16 && pip install -r requirements.txt && python groot_visual_test.py`
+- **roboharness itself is a pip dependency**, not a submodule. Showcase always uses the PyPI release.
+- **CI matrix**: Each showcase is an independent job — one failing doesn't block others.
+
+**Benefits:**
+
+- Core repo stays self-contained, no bloat
+- Users see "roboharness works with GR00T / Pi0 / LeRobot" with runnable demos
+- Issue #91 scope shifts from "support every framework in roboharness" to "showcase integrations in a dedicated repo"
+- Version changes in large models/frameworks don't break core CI
+
+**Prerequisites:** GitHub org `roboharness` already exists (no repos yet).
+
+**⚡ Action items:**
+
+- [ ] Create `.github` repo in `roboharness` org with `profile/README.md` (org landing page)
+- [ ] Create `roboharness/showcase` repo
+- [ ] Initialize skeleton: README + groot-n16/ + pi0-libero/ + lerobot-g1/ directories
+- [ ] First runnable showcase: extract `examples/lerobot_g1_native.py` as standalone showcase
+- [ ] Set up CI: GitHub Actions matrix, one job per showcase
+
+**Exit criteria:** Showcase repo has at least 3 runnable showcases (GR00T, Pi0, LeRobot), each with CI.
+
+---
+
+## Do Later
+
+### D. VLM Judge Integration
+
+Add an optional VLM evaluation path in the evaluate module. Use open-source RoboReward 4B models or StepEval's per-subgoal pattern to auto-score checkpoint screenshots.
+
+**Prerequisites:** Constraint Evaluator ships first. VLM judge is an enhancement layer on top.
+
+**Open question:** Which VLM? RoboReward 4B is purpose-trained but may not generalize; general VLMs (Claude/GPT-4o) are expensive but more capable. Likely need two paths: local small model for fast CI checks, cloud model for deep analysis.
+
+### E. Newton Physics Engine Support
+
+NVIDIA released Newton 1.0 at GTC 2026, built on Warp, claiming 475x faster than MJX, Apache 2.0, Linux Foundation governance. If it becomes the new standard GPU physics engine, roboharness needs to support it.
+
+**Not urgent.** Newton just hit 1.0 and the API may still be changing. Monitor community adoption first. Roboharness's MuJoCo support + Gymnasium wrapper already covers most scenarios.
+
+### F. RoboVerse MetaSim Evaluation
+
+RoboVerse provides a unified API across 8+ simulators (Isaac Lab, MuJoCo, SAPIEN, Genesis, PyBullet). If the API is stable, one integration = support for 8 simulators.
+
+**Needs a spike first:** Spend one session actually trying RoboVerse, evaluating API stability and integration cost. If viable, this could be the highest-ROI technical direction.
+
+### G. MCP Server Enhancements
+
+Current #70 provides a basic MCP server. Enhancement directions:
+
+- Connect to the `evaluate` module so agents get pass/fail results via MCP
+- Support returning checkpoint screenshots via MCP (base64 images)
+- Consider registering in the official MCP directory
+
+---
+
+## Not Doing
+
+Explicitly listed to prevent scope creep:
+
+- **Not a training framework**: roboharness is a testing harness, not a training pipeline
+- **Not real-time control**: No robot teleop or remote control
+- **No heavy framework dependencies in core**: GR00T/Pi0/Isaac Lab etc. live in the showcase repo
+- **No multi-agent orchestration**: Not a Cursor-style parallel agent coordination system
+- **No auto-generated AGENTS.md / CLAUDE.md**: ETH Zurich research showed auto-generation performs worse
+
+---
+
+## Issue Status Reference
+
+| Direction | Related Issue | Status |
+|-----------|--------------|--------|
+| LeRobot eval plugin | To be created | New direction |
+| Constraint Evaluator | docs/p1-constraint-evaluator.md | Design complete, awaiting implementation |
+| Showcase repo | Redefines #91 | New approach |
+| VLM judge | To be created | Design phase |
+| Newton support | None | Monitoring |
+| RoboVerse evaluation | None | Needs spike |
+| MCP enhancements | #70 | Basics complete |
+| GPU CI | #18 | Basics complete, Cirun + GCP working |
+| Isaac Lab validation | #4 | Complete |
+| ManiSkill validation | #5 | Complete |
+| SONIC | #86, #92 | Phase 1+2 complete |


### PR DESCRIPTION
## What

Two strategic planning documents based on competitive landscape deep research (April 2026).

## Files

- `docs/roadmap-2026-q2.md` — Technical roadmap, no timing estimates. "Do now": LeRobot eval plugin, Constraint Evaluator, showcase repo (github.com/roboharness/showcase). "Do later": VLM judge, Newton, RoboVerse. Explicit "Not doing" list.
- `docs/ecosystem-strategy.md` — Community distribution strategy with 14 specific action items tagged by executor (Claude Code vs human). Covers ROS community (Discourse post, awesome-ros2 PR, ros2_mcp discussion), HuggingFace (LeRobot issue contributions, HF Space), content ("Harness Engineering for Robotics" category definition), funding (Anthropic Claude for Open Source deadline June 30, Robotics Factory July 18).

## Key decisions

1. **Showcase repo pattern**: `roboharness/showcase` under existing org with thin wrappers (not submodules). Core stays self-contained. Redefines #91.
2. **LeRobot eval plugin as highest priority**: Addresses evaluation gaps (#538, #2375) in the largest robotics community.
3. **"Harness Engineering for Robotics" is an empty category**: 92+ harness engineering resources all target software dev. First to publish defines it.

Refs #91