### PR TITLE
fix: #67 — API friction fixes for WBC grasp re-integration

### DIFF
--- a/src/roboharness/backends/mujoco_meshcat.py
+++ b/src/roboharness/backends/mujoco_meshcat.py
@@ -142,12 +142,17 @@ class MuJoCoMeshcatBackend:
         return self.get_state()
 
     def get_state(self) -> dict[str, Any]:
-        """Get current simulation state."""
+        """Get current simulation state.
+
+        Returns numpy arrays for ``qpos``, ``qvel``, and ``ctrl`` so callers
+        can use them directly in numeric computations without conversion.
+        JSON serialization is handled by :class:`~roboharness._utils.NumpyEncoder`.
+        """
         return {
             "time": float(self._data.time),
-            "qpos": self._data.qpos.copy().tolist(),
-            "qvel": self._data.qvel.copy().tolist(),
-            "ctrl": self._data.ctrl.copy().tolist(),
+            "qpos": self._data.qpos.copy(),
+            "qvel": self._data.qvel.copy(),
+            "ctrl": self._data.ctrl.copy(),
         }
 
     def save_state(self) -> dict[str, Any]:

--- a/src/roboharness/core/harness.py
+++ b/src/roboharness/core/harness.py
@@ -86,6 +86,7 @@ class Harness:
         self._step_count: int = 0
         self._trial_count: int = 0
         self._checkpoint_store = CheckpointStore(self.output_dir / "snapshots")
+        self._checkpoint_step_counts: dict[str, int] = {}
         self._rerun_logger = RerunCaptureLogger(app_id=rerun_app_id) if enable_rerun else None
         self._active_protocol: TaskProtocol | None = None
 
@@ -191,6 +192,7 @@ class Harness:
         # Save checkpoint state
         sim_state = self.backend.save_state()
         self._checkpoint_store.save(checkpoint.name, sim_state)
+        self._checkpoint_step_counts[checkpoint.name] = self._step_count
 
         self._current_checkpoint_idx += 1
         return result
@@ -234,9 +236,17 @@ class Harness:
         return result
 
     def restore_checkpoint(self, name: str) -> None:
-        """Restore simulation to a previously saved checkpoint."""
+        """Restore simulation to a previously saved checkpoint.
+
+        Restores both the simulator physics state and the harness step count
+        so that ``trigger_step`` logic works correctly after a restore.
+        """
         sim_state = self._checkpoint_store.restore(name)
         self.backend.restore_state(sim_state)
+
+        # Restore step count to the value when this checkpoint was captured
+        if name in self._checkpoint_step_counts:
+            self._step_count = self._checkpoint_step_counts[name]
 
         # Reset checkpoint index to the restored one
         for i, cp in enumerate(self._checkpoints):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -79,3 +79,27 @@ def test_harness_no_more_checkpoints(tmp_path):
 
     result2 = harness.run_to_next_checkpoint([None])
     assert result2 is None
+
+
+def test_harness_restore_checkpoint_resets_step_count(tmp_path):
+    """Verify that restoring a checkpoint also restores _step_count.
+
+    Without this fix, trigger_step logic would use a stale count after restore.
+    """
+    harness = Harness(MockBackend(), output_dir=tmp_path)
+    harness.add_checkpoint("cp1", cameras=["front"])
+    harness.add_checkpoint("cp2", cameras=["front"])
+    harness.reset()
+
+    # Run 5 steps to cp1
+    harness.run_to_next_checkpoint([None] * 5)
+    step_at_cp1 = harness.step_count
+    assert step_at_cp1 == 5
+
+    # Run 5 more steps to cp2
+    harness.run_to_next_checkpoint([None] * 5)
+    assert harness.step_count == 10
+
+    # Restore to cp1 — step_count should revert to 5
+    harness.restore_checkpoint("cp1")
+    assert harness.step_count == step_at_cp1


### PR DESCRIPTION
## Summary

- **Return numpy arrays from `MuJoCoMeshcatBackend.get_state()`** instead of Python lists for `qpos`/`qvel`/`ctrl`, eliminating redundant `np.array()` wrapping in every caller. JSON serialization still works via the existing `NumpyEncoder`.
- **Fix `Harness.restore_checkpoint()` to restore `_step_count`** to the value at checkpoint capture time, fixing broken `trigger_step` logic after a restore.

These friction points were identified during API validation for WBC grasp workflow re-integration (issue #67).

Closes #67

## Test plan

- [x] New test `test_harness_restore_checkpoint_resets_step_count` verifies step_count is properly restored
- [x] All 284 existing tests pass (18 skipped for optional deps)
- [x] ruff check + ruff format + mypy all pass

https://claude.ai/code/session_0115eiVRVvtsBFPubvm7MhMD