### PR TITLE
fix: g1-native screenshots, SONIC filenames, and HF cache in CI

### DIFF
--- a/.github/pages/sonic.html
+++ b/.github/pages/sonic.html
@@ -63,9 +63,9 @@
   <h2>Architecture: Encoder + Decoder Pipeline</h2>
   <div class="pipeline">
     <div class="pipeline-step">MoCap Clip<div class="sub">CSV joint angles</div></div>
-    <div class="pipeline-step">Encoder<div class="sub">encoder_sonic.onnx</div></div>
+    <div class="pipeline-step">Encoder<div class="sub">model_encoder.onnx</div></div>
     <div class="pipeline-step">Latent Space<div class="sub">z &isin; R<sup>d</sup></div></div>
-    <div class="pipeline-step">Decoder<div class="sub">decoder_sonic.onnx</div></div>
+    <div class="pipeline-step">Decoder<div class="sub">model_decoder.onnx</div></div>
     <div class="pipeline-step">Joint Targets<div class="sub">29-DOF output</div></div>
   </div>
 </div>
@@ -75,8 +75,8 @@
   <table>
     <tr><th>Model</th><th>File</th><th>Purpose</th></tr>
     <tr><td>Planner</td><td>planner_sonic.onnx</td><td>Velocity &rarr; full-body trajectory</td></tr>
-    <tr><td>Encoder</td><td>encoder_sonic.onnx</td><td>MoCap clip &rarr; latent code</td></tr>
-    <tr><td>Decoder</td><td>decoder_sonic.onnx</td><td>Latent code &rarr; joint targets</td></tr>
+    <tr><td>Encoder</td><td>model_encoder.onnx</td><td>MoCap clip &rarr; latent code</td></tr>
+    <tr><td>Decoder</td><td>model_decoder.onnx</td><td>Latent code &rarr; joint targets</td></tr>
   </table>
   <p>Models are downloaded from <code>nvidia/GEAR-SONIC</code> on HuggingFace on first use.</p>
 </div>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
       - name: Install lerobot/unitree-g1-mujoco runtime deps
         run: uv pip install --system loguru pygame scipy pyyaml
 
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models-${{ runner.os }}-v1
+
       - name: Run native LeRobot G1 example
         env:
           MUJOCO_GL: osmesa

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,12 @@ jobs:
           uv pip install --system lerobot
           uv pip install --system loguru pygame scipy pyyaml
 
+      - name: Cache HuggingFace models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models-${{ runner.os }}-v1
+
       - name: Run MuJoCo grasp example
         env:
           MUJOCO_GL: osmesa

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ action = ctrl.compute(
 )
 ```
 
-Models (`planner_sonic.onnx`, `encoder_sonic.onnx`, `decoder_sonic.onnx`) are downloaded from HuggingFace (`nvidia/GEAR-SONIC`) on first use. Requires `pip install roboharness[demo]`. See [#86](https://github.com/MiaoDX/roboharness/issues/86) (Phase 1) and [#92](https://github.com/MiaoDX/roboharness/issues/92) (Phase 2).
+Models (`planner_sonic.onnx`, `model_encoder.onnx`, `model_decoder.onnx`) are downloaded from HuggingFace (`nvidia/GEAR-SONIC`) on first use. Requires `pip install roboharness[demo]`. See [#86](https://github.com/MiaoDX/roboharness/issues/86) (Phase 1) and [#92](https://github.com/MiaoDX/roboharness/issues/92) (Phase 2).
 
 </details>
 

--- a/examples/lerobot_g1_native.py
+++ b/examples/lerobot_g1_native.py
@@ -155,18 +155,33 @@ def _add_mujoco_rendering(
     unwrapped = getattr(env, "unwrapped", env)
 
     # Find the MuJoCo model and data on the env (attribute names vary by env)
+    # Search the unwrapped env and one level deeper (e.g. env.sim_env.mj_model
+    # for the lerobot/unitree-g1-mujoco hub env).
     model = None
     data = None
-    for attr in ("model", "_model", "mj_model"):
-        model = getattr(unwrapped, attr, None)
-        if model is not None and hasattr(model, "ncam"):
+    search_targets = [unwrapped]
+    for nested in ("sim_env", "simulator", "sim"):
+        obj = getattr(unwrapped, nested, None)
+        if obj is not None:
+            search_targets.append(obj)
+
+    for target in search_targets:
+        for attr in ("model", "_model", "mj_model"):
+            candidate = getattr(target, attr, None)
+            if candidate is not None and hasattr(candidate, "ncam"):
+                model = candidate
+                break
+        if model is not None:
             break
-        model = None
-    for attr in ("data", "_data", "mj_data"):
-        data = getattr(unwrapped, attr, None)
-        if data is not None and hasattr(data, "qpos"):
+
+    for target in search_targets:
+        for attr in ("data", "_data", "mj_data"):
+            candidate = getattr(target, attr, None)
+            if candidate is not None and hasattr(candidate, "qpos"):
+                data = candidate
+                break
+        if data is not None:
             break
-        data = None
 
     if model is None or data is None:
         print("      Warning: could not find MuJoCo model/data — no screenshots")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "mypy>=1.0",
     "pre-commit>=3.0",
     "gymnasium>=0.29",
+    "Pillow",
 ]
 
 [project.scripts]

--- a/src/roboharness/robots/unitree_g1/locomotion.py
+++ b/src/roboharness/robots/unitree_g1/locomotion.py
@@ -428,8 +428,8 @@ SONIC_DEFAULT_HEIGHT = 0.74
 SONIC_DEFAULT_NUM_TOKENS = 11
 
 # Phase 2: Encoder+Decoder model files
-SONIC_ENCODER_FILE = "encoder_sonic.onnx"
-SONIC_DECODER_FILE = "decoder_sonic.onnx"
+SONIC_ENCODER_FILE = "model_encoder.onnx"
+SONIC_DECODER_FILE = "model_decoder.onnx"
 
 # Encoder input: 29 joint pos + 29 joint vel + 1 root height + 6D rotation = 65
 SONIC_ENCODER_INPUT_DIM = 65
@@ -566,8 +566,8 @@ class SonicLocomotionController:
     full-body pose trajectories from velocity commands. Between planner calls the
     controller interpolates the 30 Hz output to 50 Hz for smooth control.
 
-    **Tracking mode** (Phase 2): Uses ``encoder_sonic.onnx`` and
-    ``decoder_sonic.onnx`` to track reference motion clips. The encoder converts
+    **Tracking mode** (Phase 2): Uses ``model_encoder.onnx`` and
+    ``model_decoder.onnx`` to track reference motion clips. The encoder converts
     a 65-dim motion reference into a 64-dim latent token, and the decoder maps
     the latent plus the current 58-dim robot state into 29-DOF joint targets.
 


### PR DESCRIPTION
## Summary

- **g1-native screenshots**: Fix `_add_mujoco_rendering()` to search nested `sim_env` for MuJoCo model/data — the hub env stores them at `env.sim_env.mj_model`/`mj_data`, not directly on the unwrapped env
- **SONIC ONNX filenames**: Correct `encoder_sonic.onnx` → `model_encoder.onnx` and `decoder_sonic.onnx` → `model_decoder.onnx` to match actual filenames on the `nvidia/GEAR-SONIC` HuggingFace repo
- **HF download caching**: Add `actions/cache` for `~/.cache/huggingface/hub` in both `pages.yml` and `ci.yml` to speed up repeated model downloads

## Test plan

- [ ] g1-native example produces screenshots (MuJoCo model/data found via nested search)
- [ ] SONIC filenames match HuggingFace repo (`model_encoder.onnx`, `model_decoder.onnx`)
- [ ] HF cache hits on second CI run (check `actions/cache` restore log)
- [ ] CI lint + tests pass
- [ ] Pages deployment succeeds with g1-native screenshots

https://claude.ai/code/session_01SVTnTNfife3vYgu79tfee5