### PR TITLE
feat: add pass/fail visual indicators to HTML reports (#138)

### DIFF
--- a/src/roboharness/reporting.py
+++ b/src/roboharness/reporting.py
@@ -7,7 +7,83 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
+from roboharness.evaluate.result import EvaluationResult, Severity, Verdict
+
 MeshcatMode = Literal["iframe", "link", "none"]
+
+_VERDICT_CSS = {
+    Verdict.PASS: "verdict-pass",
+    Verdict.DEGRADED: "verdict-degraded",
+    Verdict.FAIL: "verdict-fail",
+}
+
+_VERDICT_LABEL = {
+    Verdict.PASS: "PASS",
+    Verdict.DEGRADED: "DEGRADED",
+    Verdict.FAIL: "FAIL",
+}
+
+
+def _build_verdict_banner(result: EvaluationResult) -> str:
+    """Build the HTML verdict banner shown at the top of the report."""
+    css_class = _VERDICT_CSS[result.verdict]
+    label = _VERDICT_LABEL[result.verdict]
+    passed_count = len(result.passed)
+    total = len(result.results)
+    return (
+        f'<div class="verdict {css_class}">'
+        f"{label} &mdash; {passed_count}/{total} constraints satisfied"
+        f"</div>"
+    )
+
+
+def _build_eval_summary(result: EvaluationResult) -> str:
+    """Build the constraint evaluation summary table."""
+    rows: list[str] = []
+    for r in result.results:
+        if r.passed:
+            icon = '<span class="badge badge-pass">PASS</span>'
+        else:
+            icon = '<span class="badge badge-fail">FAIL</span>'
+
+        if isinstance(r.threshold, tuple):
+            expected = f"in [{r.threshold[0]}, {r.threshold[1]}]"
+        else:
+            expected = f"{r.operator.value} {r.threshold}"
+
+        actual = f"{r.actual_value}" if r.actual_value is not None else "missing"
+        severity_cls = f"severity-{r.severity.value}"
+        rows.append(
+            f"<tr>"
+            f"<td>{r.metric}</td>"
+            f"<td>{expected}</td>"
+            f"<td>{actual}</td>"
+            f'<td><span class="severity {severity_cls}">{r.severity.value}</span></td>'
+            f"<td>{icon}</td>"
+            f"</tr>"
+        )
+
+    return (
+        '<div class="eval-summary">'
+        "<h3>Constraint Evaluation</h3>"
+        '<table class="eval-table">'
+        "<tr><th>Metric</th><th>Expected</th><th>Actual</th>"
+        "<th>Severity</th><th>Result</th></tr>" + "".join(rows) + "</table></div>"
+    )
+
+
+def _phase_badge(result: EvaluationResult, checkpoint_name: str) -> str:
+    """Build a pass/fail badge for a checkpoint if phase-specific assertions exist."""
+    phase_results = [r for r in result.results if r.phase == checkpoint_name]
+    if not phase_results:
+        return ""
+    all_passed = all(r.passed for r in phase_results)
+    if all_passed:
+        return ' <span class="badge badge-pass">PASS</span>'
+    has_critical = any(not r.passed and r.severity == Severity.CRITICAL for r in phase_results)
+    if has_critical:
+        return ' <span class="badge badge-fail">FAIL</span>'
+    return ' <span class="badge badge-degraded">DEGRADED</span>'
 
 
 def generate_html_report(
@@ -21,6 +97,7 @@ def generate_html_report(
     footer_text: str = "",
     trial_name: str = "trial_001",
     meshcat_mode: MeshcatMode = "iframe",
+    evaluation_result: EvaluationResult | None = None,
 ) -> Path:
     """Generate a self-contained HTML report showing all checkpoint captures.
 
@@ -46,6 +123,10 @@ def generate_html_report(
         Trial subdirectory name.
     meshcat_mode:
         How to embed Meshcat scenes: "iframe" (embedded), "link" (new tab), or "none".
+    evaluation_result:
+        Optional constraint evaluation result. When provided, the report includes
+        a verdict banner (green/yellow/red), a constraint summary table, and
+        per-checkpoint pass/fail badges for phase-specific assertions.
 
     Returns
     -------
@@ -136,9 +217,11 @@ def generate_html_report(
             else f'<div class="views">{"".join(images_html)}</div>'
         )
 
+        checkpoint_badge = _phase_badge(evaluation_result, cp_name) if evaluation_result else ""
+
         rows_html.append(
             f'<div class="checkpoint">'
-            f"<h2>{cp_name}</h2>"
+            f"<h2>{cp_name}{checkpoint_badge}</h2>"
             f"<p>{' | '.join(meta_parts)}</p>"
             f"{views_wrap}"
             f"</div>"
@@ -149,6 +232,9 @@ def generate_html_report(
 
     subtitle_html = f"<p>{subtitle}</p>" if subtitle else ""
     summary_block = f'<div class="summary">{summary_html}</div>' if summary_html else ""
+
+    verdict_banner = _build_verdict_banner(evaluation_result) if evaluation_result else ""
+    eval_summary = _build_eval_summary(evaluation_result) if evaluation_result else ""
 
     html = f"""\
 <!DOCTYPE html>
@@ -178,12 +264,37 @@ def generate_html_report(
   .meshcat-link:hover {{ opacity: 0.85; }}
   .meshcat-viewer p {{ margin: 8px 0 0; font-size: 13px; color: #888; }}
   .footer {{ margin-top: 30px; color: #999; font-size: 12px; }}
+  .verdict {{ padding: 12px 20px; border-radius: 8px; font-weight: bold; font-size: 18px;
+              margin: 20px 0; text-align: center; }}
+  .verdict-pass {{ background: #d4edda; color: #155724; border: 1px solid #c3e6cb; }}
+  .verdict-degraded {{ background: #fff3cd; color: #856404; border: 1px solid #ffeeba; }}
+  .verdict-fail {{ background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; }}
+  .eval-summary {{ background: white; border-radius: 8px; padding: 20px; margin: 20px 0;
+                   box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+  .eval-summary h3 {{ color: {accent_color}; margin-top: 0; }}
+  .eval-table {{ width: 100%; border-collapse: collapse; }}
+  .eval-table th, .eval-table td {{ padding: 8px 12px; text-align: left;
+                                    border-bottom: 1px solid #eee; }}
+  .eval-table th {{ background: #f8f9fa; font-weight: 600; }}
+  .badge {{ display: inline-block; padding: 2px 8px; border-radius: 4px;
+            font-size: 12px; font-weight: bold; text-transform: uppercase; }}
+  .badge-pass {{ background: #d4edda; color: #155724; }}
+  .badge-degraded {{ background: #fff3cd; color: #856404; }}
+  .badge-fail {{ background: #f8d7da; color: #721c24; }}
+  .severity {{ display: inline-block; padding: 1px 6px; border-radius: 3px;
+               font-size: 11px; text-transform: uppercase; }}
+  .severity-critical {{ background: #f8d7da; color: #721c24; }}
+  .severity-major {{ background: #fff3cd; color: #856404; }}
+  .severity-minor {{ background: #e2e3e5; color: #383d41; }}
+  .severity-info {{ background: #d1ecf1; color: #0c5460; }}
 </style>
 </head>
 <body>
 <h1>{title}</h1>
 {subtitle_html}
+{verdict_banner}
 {summary_block}
+{eval_summary}
 {"".join(rows_html)}
 <div class="footer">
   {footer_text}

--- a/tests/test_assertions.py
+++ b/tests/test_assertions.py
@@ -595,3 +595,154 @@ class TestEvaluateBatchCLI:
 
         ret = main(["evaluate-batch", "/nonexistent/dir"])
         assert ret == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: YAML constraints -> evaluate -> HTML report with verdict
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateToReportEndToEnd:
+    """Full workflow: load YAML constraints, evaluate report, generate HTML with verdict."""
+
+    @pytest.fixture
+    def grasp_output(self, tmp_path: Path) -> Path:
+        """Create a realistic harness output with checkpoints and a report."""
+        import base64
+
+        tiny_png = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4"
+            "nGP4z8BQDwAEgAF/pooBPQAAAABJRU5ErkJggg=="
+        )
+        trial_dir = tmp_path / "grasp" / "trial_001"
+
+        for cp_name, step, sim_time in [
+            ("01_pregrasp", 0, 0.0),
+            ("02_contact", 50, 0.5),
+            ("03_grasp", 100, 1.0),
+            ("04_lift", 150, 1.5),
+        ]:
+            cp_dir = trial_dir / cp_name
+            cp_dir.mkdir(parents=True)
+            (cp_dir / "metadata.json").write_text(
+                json.dumps({"step": step, "sim_time": sim_time, "cameras": ["front"]})
+            )
+            (cp_dir / "front_rgb.png").write_bytes(tiny_png)
+
+        # Write autonomous_report.json (what the evaluator reads)
+        report = {
+            "summary_metrics": {
+                "grip_center_error_mm": 8.2,
+                "pinch_gap_error_mm": 6.1,
+                "pinch_elevation_deg": 12.0,
+                "index_middle_vertical_deg": 18.5,
+            },
+            "snapshot_metrics": {
+                "03_grasp": {
+                    "grip_center_error_mm": 7.5,
+                    "pinch_gap_error_mm": 5.8,
+                },
+            },
+        }
+        (trial_dir / "autonomous_report.json").write_text(json.dumps(report))
+
+        return tmp_path
+
+    def test_yaml_to_evaluate_to_html_pass(self, grasp_output: Path) -> None:
+        """End-to-end: load grasp_default.yaml, evaluate passing report, HTML shows PASS."""
+        from roboharness.evaluate.assertions import AssertionEngine
+        from roboharness.evaluate.constraints import load_constraints
+        from roboharness.reporting import generate_html_report
+
+        # Step 1: Load constraints from the project's actual YAML file
+        constraints_path = Path(__file__).parent.parent / "constraints" / "grasp_default.yaml"
+        yaml = pytest.importorskip("yaml", reason="PyYAML not installed")  # noqa: F841
+        assertions = load_constraints(constraints_path)
+        assert len(assertions) == 4
+
+        # Step 2: Evaluate the report
+        report_path = grasp_output / "grasp" / "trial_001" / "autonomous_report.json"
+        report_data = json.loads(report_path.read_text())
+        engine = AssertionEngine(assertions)
+        result = engine.evaluate(report_data, report_path=str(report_path))
+
+        # All metrics are within thresholds
+        assert result.verdict == Verdict.PASS
+
+        # Step 3: Generate HTML report with evaluation
+        html_path = generate_html_report(
+            grasp_output,
+            "grasp",
+            title="Grasp Evaluation",
+            evaluation_result=result,
+        )
+        html = html_path.read_text()
+
+        # Verify verdict banner
+        assert "verdict-pass" in html
+        assert "PASS" in html
+        assert "4/4 constraints satisfied" in html
+
+        # Verify constraint summary table
+        assert "grip_center_error_mm" in html
+        assert "pinch_gap_error_mm" in html
+        assert "Constraint Evaluation" in html
+
+        # Verify checkpoints are still rendered
+        assert "01_pregrasp" in html
+        assert "04_lift" in html
+
+    def test_yaml_to_evaluate_to_html_fail(self, grasp_output: Path) -> None:
+        """End-to-end: evaluate failing report, HTML shows FAIL with red indicators."""
+        from roboharness.evaluate.assertions import AssertionEngine
+        from roboharness.evaluate.constraints import load_constraints
+        from roboharness.reporting import generate_html_report
+
+        constraints_path = Path(__file__).parent.parent / "constraints" / "grasp_default.yaml"
+        yaml = pytest.importorskip("yaml", reason="PyYAML not installed")  # noqa: F841
+        assertions = load_constraints(constraints_path)
+
+        # Override report with failing metrics
+        failing_report = {
+            "summary_metrics": {
+                "grip_center_error_mm": 60.0,  # > 50.0 critical threshold
+                "pinch_gap_error_mm": 20.0,  # > 15.0 critical threshold
+                "pinch_elevation_deg": 5.0,
+                "index_middle_vertical_deg": 10.0,
+            },
+            "snapshot_metrics": {},
+        }
+        report_path = grasp_output / "grasp" / "trial_001" / "autonomous_report.json"
+        report_path.write_text(json.dumps(failing_report))
+
+        engine = AssertionEngine(assertions)
+        result = engine.evaluate(failing_report, report_path=str(report_path))
+        assert result.verdict == Verdict.FAIL
+
+        html_path = generate_html_report(
+            grasp_output,
+            "grasp",
+            title="Grasp Evaluation - Failure",
+            evaluation_result=result,
+        )
+        html = html_path.read_text()
+
+        # Verify fail verdict
+        assert "verdict-fail" in html
+        assert "FAIL" in html
+        assert "2/4 constraints satisfied" in html
+
+        # Verify failing metrics shown
+        body = html.split("</style>")[1]
+        assert "badge-fail" in body
+
+    def test_cli_evaluate_with_yaml_constraints(self, grasp_output: Path) -> None:
+        """End-to-end: CLI evaluate command with real YAML constraints."""
+        from roboharness.cli import main
+
+        constraints_path = Path(__file__).parent.parent / "constraints" / "grasp_default.yaml"
+        yaml = pytest.importorskip("yaml", reason="PyYAML not installed")  # noqa: F841
+        report_path = grasp_output / "grasp" / "trial_001" / "autonomous_report.json"
+
+        ret = main(["evaluate", str(report_path), "--constraints", str(constraints_path)])
+        assert ret == 0  # All pass

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from roboharness.evaluate.assertions import AssertionEngine, MetricAssertion
+from roboharness.evaluate.result import EvaluationResult, Operator, Severity
 from roboharness.reporting import generate_html_report
 
 
@@ -216,3 +218,255 @@ def test_generate_report_accent_color(tmp_path):
     report_path = generate_html_report(tmp_path, "task", accent_color="#ff0000")
     html = report_path.read_text()
     assert "#ff0000" in html
+
+
+# ---------------------------------------------------------------------------
+# Evaluation integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_passing_result() -> EvaluationResult:
+    """Create an EvaluationResult where all assertions pass."""
+    assertions = [
+        MetricAssertion("grip_center_error_mm", Operator.LT, 50.0, Severity.CRITICAL),
+        MetricAssertion("pinch_gap_error_mm", Operator.LT, 15.0, Severity.CRITICAL),
+    ]
+    report = {
+        "summary_metrics": {
+            "grip_center_error_mm": 5.0,
+            "pinch_gap_error_mm": 8.0,
+        }
+    }
+    return AssertionEngine(assertions).evaluate(report)
+
+
+def _make_failing_result() -> EvaluationResult:
+    """Create an EvaluationResult with critical failures."""
+    assertions = [
+        MetricAssertion("grip_center_error_mm", Operator.LT, 50.0, Severity.CRITICAL),
+        MetricAssertion("pinch_gap_error_mm", Operator.LT, 15.0, Severity.CRITICAL),
+    ]
+    report = {
+        "summary_metrics": {
+            "grip_center_error_mm": 60.0,
+            "pinch_gap_error_mm": 20.0,
+        }
+    }
+    return AssertionEngine(assertions).evaluate(report)
+
+
+def _make_degraded_result() -> EvaluationResult:
+    """Create an EvaluationResult with major (not critical) failures."""
+    assertions = [
+        MetricAssertion("grip_center_error_mm", Operator.LT, 50.0, Severity.CRITICAL),
+        MetricAssertion("pinch_elevation_deg", Operator.LT, 15.0, Severity.MAJOR),
+    ]
+    report = {
+        "summary_metrics": {
+            "grip_center_error_mm": 5.0,
+            "pinch_elevation_deg": 20.0,
+        }
+    }
+    return AssertionEngine(assertions).evaluate(report)
+
+
+def _make_phase_result() -> EvaluationResult:
+    """Create an EvaluationResult with phase-specific assertions."""
+    assertions = [
+        MetricAssertion("grip_center_error_mm", Operator.LT, 50.0, Severity.CRITICAL),
+        MetricAssertion(
+            "grip_center_error_mm", Operator.LT, 10.0, Severity.CRITICAL, phase="02_grasp"
+        ),
+    ]
+    report = {
+        "summary_metrics": {"grip_center_error_mm": 5.0},
+        "snapshot_metrics": {"02_grasp": {"grip_center_error_mm": 9.0}},
+    }
+    return AssertionEngine(assertions).evaluate(report)
+
+
+class TestReportWithEvaluation:
+    def test_no_evaluation_unchanged(self, tmp_path):
+        """Report without evaluation_result produces no verdict elements."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        report_path = generate_html_report(tmp_path, "task")
+        html = report_path.read_text()
+        assert "verdict" not in html.split("<style>")[0]  # not in body
+        assert "Constraint Evaluation" not in html
+
+    def test_pass_verdict_banner(self, tmp_path):
+        """Passing evaluation shows green PASS banner."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        result = _make_passing_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "verdict-pass" in html
+        assert "PASS" in html
+        assert "2/2 constraints satisfied" in html
+
+    def test_fail_verdict_banner(self, tmp_path):
+        """Failing evaluation shows red FAIL banner."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        result = _make_failing_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "verdict-fail" in html
+        assert "FAIL" in html
+        assert "0/2 constraints satisfied" in html
+
+    def test_degraded_verdict_banner(self, tmp_path):
+        """Degraded evaluation shows yellow DEGRADED banner."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        result = _make_degraded_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "verdict-degraded" in html
+        assert "DEGRADED" in html
+        assert "1/2 constraints satisfied" in html
+
+    def test_eval_summary_table(self, tmp_path):
+        """Evaluation summary table shows metric details."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        result = _make_failing_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "Constraint Evaluation" in html
+        assert "grip_center_error_mm" in html
+        assert "pinch_gap_error_mm" in html
+        assert "lt 50.0" in html
+        assert "60.0" in html
+        assert "badge-fail" in html
+        assert "severity-critical" in html
+
+    def test_eval_summary_pass_badges(self, tmp_path):
+        """Passing assertions show PASS badges in summary, no FAIL badges in body."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        result = _make_passing_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        body = html.split("</style>")[1]
+        assert "badge-pass" in body
+        assert "badge-fail" not in body
+
+    def test_phase_specific_badge(self, tmp_path):
+        """Checkpoint with phase-specific assertions gets a badge."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "01_start", step=0)
+        _create_checkpoint(trial_dir, "02_grasp", step=100)
+
+        result = _make_phase_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        # 02_grasp should have a PASS badge (9.0 < 10.0)
+        assert "02_grasp" in html
+        # The phase badge should appear next to the checkpoint name
+        assert 'badge badge-pass">PASS</span>' in html
+
+    def test_phase_badge_not_on_unrelated_checkpoint(self, tmp_path):
+        """Checkpoints without phase-specific assertions get no badge."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "01_start", step=0)
+        _create_checkpoint(trial_dir, "02_grasp", step=100)
+
+        result = _make_phase_result()
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        # 01_start should NOT have a badge — extract just that section
+        start_idx = html.index("01_start")
+        grasp_idx = html.index("02_grasp")
+        start_section = html[start_idx:grasp_idx]
+        assert "badge" not in start_section
+
+    def test_phase_badge_fail(self, tmp_path):
+        """Checkpoint with critical phase failure shows FAIL badge."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "02_grasp", step=100)
+
+        assertions = [
+            MetricAssertion(
+                "grip_center_error_mm",
+                Operator.LT,
+                10.0,
+                Severity.CRITICAL,
+                phase="02_grasp",
+            ),
+        ]
+        result = AssertionEngine(assertions).evaluate(
+            {"snapshot_metrics": {"02_grasp": {"grip_center_error_mm": 50.0}}}
+        )
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert 'badge badge-fail">FAIL</span>' in html
+
+    def test_phase_badge_degraded(self, tmp_path):
+        """Checkpoint with major (non-critical) phase failure shows DEGRADED badge."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "02_grasp", step=100)
+
+        assertions = [
+            MetricAssertion(
+                "elevation_deg",
+                Operator.LT,
+                15.0,
+                Severity.MAJOR,
+                phase="02_grasp",
+            ),
+        ]
+        result = AssertionEngine(assertions).evaluate(
+            {"snapshot_metrics": {"02_grasp": {"elevation_deg": 20.0}}}
+        )
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert 'badge badge-degraded">DEGRADED</span>' in html
+
+    def test_missing_metric_shown(self, tmp_path):
+        """Missing metric value is displayed as 'missing' in summary."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        assertions = [
+            MetricAssertion("nonexistent_metric", Operator.LT, 10.0, Severity.CRITICAL),
+        ]
+        result = AssertionEngine(assertions).evaluate({"summary_metrics": {}})
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "missing" in html
+        assert "nonexistent_metric" in html
+
+    def test_in_range_assertion_display(self, tmp_path):
+        """In-range assertion shows threshold range correctly."""
+        trial_dir = tmp_path / "task" / "trial_001"
+        trial_dir.mkdir(parents=True)
+        _create_checkpoint(trial_dir, "cp1", step=1)
+
+        assertions = [
+            MetricAssertion("force", Operator.IN_RANGE, (1.0, 10.0), Severity.MAJOR),
+        ]
+        result = AssertionEngine(assertions).evaluate({"summary_metrics": {"force": 5.0}})
+        report_path = generate_html_report(tmp_path, "task", evaluation_result=result)
+        html = report_path.read_text()
+        assert "in [1.0, 10.0]" in html
+        assert "5.0" in html


### PR DESCRIPTION
## Summary
- Add verdict banner (green/yellow/red) for PASS/DEGRADED/FAIL to HTML reports
- Add constraint evaluation summary table with per-metric results
- Add per-checkpoint phase badges for phase-specific assertions
- Backward compatible: reports without evaluation look identical

Closes #138

## Test plan
- [x] 25 reporting tests pass (13 existing + 12 new)
- [x] 3 end-to-end tests: YAML constraints → evaluate → HTML report
- [x] CLI evaluate command works end-to-end
- [x] reporting.py at 100% coverage
- [x] ruff check + format pass
- [x] mypy passes

https://claude.ai/code/session_016o9c6AscjvYaSM1yYC1HAT