### PR TITLE
fix: #142 — MCP server enhancements (evaluate + screenshots)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -61,13 +61,14 @@ Checkpoints save to `harness_output/<task>/trial_001/<checkpoint>/`:
 
 ## MCP server (optional)
 
-When roboharness runs as a tool service alongside other MCP tools, three tools are exposed:
+When roboharness runs as a tool service alongside other MCP tools, four tools are exposed:
 
 | Tool | Purpose |
 |------|---------|
-| `capture_checkpoint` | Pause simulation, capture multi-view screenshots + state |
+| `capture_checkpoint` | Pause simulation, capture multi-view screenshots + state (optional base64 images) |
 | `evaluate_constraints` | Run constraint evaluator on a report, return verdict |
 | `compare_baselines` | Compare current success rate against evaluation history |
+| `evaluate_batch_trials` | Evaluate all trials in a directory, return aggregate pass/fail with success rate |
 
 ```bash
 pip install mcp                        # additional dependency
@@ -84,10 +85,12 @@ server.run()                           # blocks, listens on stdio
 
 ### Tool parameters
 
-**`capture_checkpoint`** — `checkpoint_name` (string, optional), `cameras` (list of strings, default `["front"]`).
+**`capture_checkpoint`** — `checkpoint_name` (string, optional), `cameras` (list of strings, default `["front"]`), `include_images` (boolean, default false — when true, each view includes an `rgb_base64` field with a base64-encoded PNG screenshot).
 
 **`evaluate_constraints`** — `report` (object with `summary_metrics` / `snapshot_metrics`), `assertions` (list of `{metric, operator, threshold}` dicts; operators: `lt`, `le`, `eq`, `gt`, `ge`, `in_range`).
 
 **`compare_baselines`** — `task` (string), `current_rate` (float 0–1), `window` (int, default 5), `threshold` (float, default 0.1).
+
+**`evaluate_batch_trials`** — `results_dir` (string, path to directory with `autonomous_report.json` files), `assertions` (optional list of assertion dicts — uses grasp defaults when omitted), `min_success_rate` (optional float 0–1 — when set, result includes `ci_passed` boolean).
 
 Business logic lives in `roboharness.mcp.tools.HarnessTools` and can be called directly without the MCP SDK.

--- a/src/roboharness/mcp/__init__.py
+++ b/src/roboharness/mcp/__init__.py
@@ -5,8 +5,11 @@ with running simulations via the standard MCP protocol.
 
 Tools provided:
   - ``capture_checkpoint`` -- capture multi-view screenshots and state
+      (optional base64-encoded PNG images via ``include_images``)
   - ``evaluate_constraints`` -- run constraint evaluator on a report
   - ``compare_baselines`` -- compare current run against history
+  - ``evaluate_batch_trials`` -- evaluate all trials in a directory and
+      return aggregate pass/fail results with success rate
 """
 
 from __future__ import annotations

--- a/src/roboharness/mcp/server.py
+++ b/src/roboharness/mcp/server.py
@@ -49,6 +49,7 @@ def create_server(
         "capture_checkpoint": tools.capture_checkpoint,
         "evaluate_constraints": tools.evaluate_constraints,
         "compare_baselines": tools.compare_baselines,
+        "evaluate_batch_trials": tools.evaluate_batch_trials,
     }
 
     @server.list_tools()

--- a/src/roboharness/mcp/tools.py
+++ b/src/roboharness/mcp/tools.py
@@ -10,6 +10,8 @@ pure business logic.  The thin MCP server wrapper lives in ``server.py``.
 
 from __future__ import annotations
 
+import base64
+import io
 from pathlib import Path
 from typing import Any
 
@@ -19,7 +21,9 @@ from roboharness.core.capture import CameraView, CaptureResult
 from roboharness.core.checkpoint import Checkpoint
 from roboharness.core.harness import Harness
 from roboharness.evaluate.assertions import AssertionEngine
+from roboharness.evaluate.batch import evaluate_batch
 from roboharness.evaluate.constraints import _parse_assertion
+from roboharness.evaluate.defaults import GRASP_DEFAULTS
 from roboharness.storage.history import EvaluationHistory
 
 # JSON-schema descriptions exposed by the MCP server layer.
@@ -41,6 +45,15 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "type": "array",
                     "items": {"type": "string"},
                     "description": 'Camera names to capture (default: ["front"]).',
+                },
+                "include_images": {
+                    "type": "boolean",
+                    "description": (
+                        "Include base64-encoded PNG screenshots in the response "
+                        "(default: false). When true, each view includes an "
+                        "'rgb_base64' field with the PNG data."
+                    ),
+                    "default": False,
                 },
             },
         },
@@ -112,15 +125,85 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
             "required": ["task", "current_rate"],
         },
     },
+    {
+        "name": "evaluate_batch_trials",
+        "description": (
+            "Evaluate all trial reports in a directory against metric "
+            "assertions and return aggregate pass/fail results with "
+            "success rate, verdict counts, and per-constraint failure details."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "results_dir": {
+                    "type": "string",
+                    "description": (
+                        "Path to a directory containing autonomous_report.json "
+                        "files (searched recursively)."
+                    ),
+                },
+                "assertions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "metric": {"type": "string"},
+                            "operator": {
+                                "type": "string",
+                                "enum": ["lt", "le", "eq", "gt", "ge", "in_range"],
+                            },
+                            "threshold": {},
+                            "severity": {
+                                "type": "string",
+                                "enum": ["critical", "major", "minor", "info"],
+                                "default": "major",
+                            },
+                            "phase": {"type": "string", "default": "*"},
+                        },
+                        "required": ["metric", "operator", "threshold"],
+                    },
+                    "description": (
+                        "Metric assertions to evaluate. If omitted, uses "
+                        "built-in grasp defaults (grip_center_error_mm, "
+                        "pinch_gap_error_mm, etc.)."
+                    ),
+                },
+                "min_success_rate": {
+                    "type": "number",
+                    "description": (
+                        "Optional minimum success rate threshold (0.0-1.0). "
+                        "When set, the result includes a 'ci_passed' boolean."
+                    ),
+                },
+            },
+            "required": ["results_dir"],
+        },
+    },
 ]
 
 
-def _camera_view_to_dict(view: CameraView) -> dict[str, Any]:
+def _encode_rgb_base64(rgb: np.ndarray) -> str:
+    """Encode an RGB numpy array as a base64 PNG string."""
+    from PIL import Image
+
+    img = Image.fromarray(rgb)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _camera_view_to_dict(
+    view: CameraView,
+    *,
+    include_image: bool = False,
+) -> dict[str, Any]:
     """Serialise a CameraView to a JSON-friendly dict."""
     result: dict[str, Any] = {
         "name": view.name,
         "rgb_shape": list(view.rgb.shape),
     }
+    if include_image:
+        result["rgb_base64"] = _encode_rgb_base64(view.rgb)
     if view.depth is not None:
         result["depth_shape"] = list(view.depth.shape)
     if view.segmentation is not None:
@@ -128,7 +211,11 @@ def _camera_view_to_dict(view: CameraView) -> dict[str, Any]:
     return result
 
 
-def _capture_to_dict(capture: CaptureResult) -> dict[str, Any]:
+def _capture_to_dict(
+    capture: CaptureResult,
+    *,
+    include_images: bool = False,
+) -> dict[str, Any]:
     """Serialise a CaptureResult to a JSON-friendly dict."""
     state = {}
     for k, v in capture.state.items():
@@ -141,7 +228,7 @@ def _capture_to_dict(capture: CaptureResult) -> dict[str, Any]:
         "checkpoint_name": capture.checkpoint_name,
         "step": capture.step,
         "sim_time": capture.sim_time,
-        "views": [_camera_view_to_dict(v) for v in capture.views],
+        "views": [_camera_view_to_dict(v, include_image=include_images) for v in capture.views],
         "state": state,
         "metadata": capture.metadata,
     }
@@ -174,18 +261,20 @@ class HarnessTools:
         self,
         checkpoint_name: str | None = None,
         cameras: list[str] | None = None,
+        include_images: bool = False,
     ) -> dict[str, Any]:
         """Capture multi-view screenshots and simulation state.
 
         Returns a JSON-serialisable dict describing the captured views,
-        simulation state, and metadata.
+        simulation state, and metadata.  When *include_images* is ``True``,
+        each view includes an ``rgb_base64`` field with a base64-encoded PNG.
         """
         checkpoint = Checkpoint(
             name=checkpoint_name or f"step_{self._harness.step_count}",
             cameras=cameras or ["front"],
         )
         capture = self._harness.capture(checkpoint)
-        return _capture_to_dict(capture)
+        return _capture_to_dict(capture, include_images=include_images)
 
     # ---- Tool: evaluate_constraints --------------------------------------
 
@@ -230,3 +319,37 @@ class HarnessTools:
             threshold=threshold,
         )
         return trend.to_dict()
+
+    # ---- Tool: evaluate_batch_trials -------------------------------------
+
+    def evaluate_batch_trials(
+        self,
+        results_dir: str,
+        assertions: list[dict[str, Any]] | None = None,
+        min_success_rate: float | None = None,
+    ) -> dict[str, Any]:
+        """Evaluate all trial reports in a directory and return aggregate results.
+
+        Parameters
+        ----------
+        results_dir:
+            Path to a directory containing ``autonomous_report.json`` files.
+        assertions:
+            Optional list of assertion dicts.  When ``None``, the built-in
+            ``GRASP_DEFAULTS`` preset is used.
+        min_success_rate:
+            Optional CI threshold.  When set, the result includes a
+            ``ci_passed`` boolean indicating whether the success rate
+            meets the threshold.
+        """
+        parsed = (
+            [_parse_assertion(a) for a in assertions]
+            if assertions is not None
+            else list(GRASP_DEFAULTS)
+        )
+        batch = evaluate_batch(Path(results_dir), parsed)
+        result = batch.to_dict()
+        if min_success_rate is not None:
+            result["ci_passed"] = batch.success_rate >= min_success_rate
+            result["min_success_rate"] = min_success_rate
+        return result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -132,15 +132,20 @@ def test_create_server_registers_both_handlers(server):
 # ── list_tools ──────────────────────────────────────────────────────────
 
 
-def test_list_tools_returns_three_tools(server):
+def test_list_tools_returns_four_tools(server):
     tools = _run(server._list_handler())
-    assert len(tools) == 3
+    assert len(tools) == 4
 
 
 def test_list_tools_has_expected_names(server):
     tools = _run(server._list_handler())
     names = {t.name for t in tools}
-    assert names == {"capture_checkpoint", "evaluate_constraints", "compare_baselines"}
+    assert names == {
+        "capture_checkpoint",
+        "evaluate_constraints",
+        "compare_baselines",
+        "evaluate_batch_trials",
+    }
 
 
 def test_list_tools_each_has_description_and_schema(server):
@@ -187,6 +192,20 @@ def test_call_compare_baselines_no_history(server):
     payload = json.loads(result[0].text)
     assert payload["regressed"] is False
     assert payload["previous_rate"] is None
+
+
+def test_call_evaluate_batch_trials_empty(server, tmp_path):
+    empty_dir = tmp_path / "empty_trials"
+    empty_dir.mkdir()
+    result = _run(
+        server._call_handler(
+            "evaluate_batch_trials",
+            {"results_dir": str(empty_dir)},
+        )
+    )
+    payload = json.loads(result[0].text)
+    assert payload["total_trials"] == 0
+    assert payload["success_rate"] == 0.0
 
 
 def test_call_unknown_tool_returns_error(server):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import json
+
 import pytest
 
 from roboharness.core.harness import Harness
@@ -30,9 +33,14 @@ def tools(harness, tmp_path):
 
 
 def test_tool_schemas_are_valid():
-    assert len(TOOL_SCHEMAS) == 3
+    assert len(TOOL_SCHEMAS) == 4
     names = {s["name"] for s in TOOL_SCHEMAS}
-    assert names == {"capture_checkpoint", "evaluate_constraints", "compare_baselines"}
+    assert names == {
+        "capture_checkpoint",
+        "evaluate_constraints",
+        "compare_baselines",
+        "evaluate_batch_trials",
+    }
     for schema in TOOL_SCHEMAS:
         assert "description" in schema
         assert "inputSchema" in schema
@@ -215,3 +223,163 @@ def test_parse_assertion_full():
     assert a.severity.value == "critical"
     assert a.phase == "lift"
     assert a.threshold == (0.0, 1.0)
+
+
+# ── capture_checkpoint with include_images ──────────────────────────────
+
+
+def test_capture_checkpoint_include_images(tools):
+    result = tools.capture_checkpoint(include_images=True)
+    view = result["views"][0]
+    assert "rgb_base64" in view
+    # Decode base64 and verify it's valid PNG data
+    raw = base64.b64decode(view["rgb_base64"])
+    assert raw[:8] == b"\x89PNG\r\n\x1a\n"  # PNG magic bytes
+
+
+def test_capture_checkpoint_without_images_has_no_base64(tools):
+    result = tools.capture_checkpoint(include_images=False)
+    view = result["views"][0]
+    assert "rgb_base64" not in view
+
+
+def test_capture_checkpoint_include_images_multiple_cameras(tools):
+    result = tools.capture_checkpoint(cameras=["front", "side"], include_images=True)
+    assert len(result["views"]) == 2
+    for view in result["views"]:
+        assert "rgb_base64" in view
+        raw = base64.b64decode(view["rgb_base64"])
+        assert raw[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+# ── evaluate_batch_trials ───────────────────────────────────────────────
+
+
+def _create_report(directory, metrics, case_id="test"):
+    """Helper to create an autonomous_report.json in a directory."""
+    directory.mkdir(parents=True, exist_ok=True)
+    report = {
+        "case_id": case_id,
+        "summary_metrics": metrics,
+    }
+    report_path = directory / "autonomous_report.json"
+    report_path.write_text(json.dumps(report))
+    return report_path
+
+
+def test_evaluate_batch_trials_empty_dir(tools, tmp_path):
+    results_dir = tmp_path / "empty"
+    results_dir.mkdir()
+    result = tools.evaluate_batch_trials(str(results_dir))
+    assert result["total_trials"] == 0
+    assert result["success_rate"] == 0.0
+
+
+def test_evaluate_batch_trials_all_pass(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    _create_report(
+        results_dir / "trial_001",
+        {
+            "grip_center_error_mm": 10.0,
+            "pinch_gap_error_mm": 5.0,
+            "pinch_elevation_deg": 3.0,
+            "index_middle_vertical_deg": 5.0,
+        },
+        case_id="trial_001",
+    )
+    _create_report(
+        results_dir / "trial_002",
+        {
+            "grip_center_error_mm": 15.0,
+            "pinch_gap_error_mm": 8.0,
+            "pinch_elevation_deg": 7.0,
+            "index_middle_vertical_deg": 10.0,
+        },
+        case_id="trial_002",
+    )
+
+    result = tools.evaluate_batch_trials(str(results_dir))
+    assert result["total_trials"] == 2
+    assert result["success_rate"] == 1.0
+    assert result["verdicts"]["pass"] == 2
+
+
+def test_evaluate_batch_trials_with_failures(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    all_pass_metrics = {
+        "grip_center_error_mm": 10.0,
+        "pinch_gap_error_mm": 5.0,
+        "pinch_elevation_deg": 3.0,
+        "index_middle_vertical_deg": 5.0,
+    }
+    # Passing trial
+    _create_report(results_dir / "trial_001", all_pass_metrics, case_id="pass")
+    # Failing trial (grip_center_error_mm exceeds 50.0 critical threshold)
+    _create_report(
+        results_dir / "trial_002",
+        {**all_pass_metrics, "grip_center_error_mm": 60.0},
+        case_id="fail",
+    )
+
+    result = tools.evaluate_batch_trials(str(results_dir))
+    assert result["total_trials"] == 2
+    assert result["success_rate"] == 0.5
+    assert result["verdicts"].get("pass", 0) == 1
+    assert result["verdicts"].get("fail", 0) == 1
+
+
+def test_evaluate_batch_trials_custom_assertions(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    _create_report(
+        results_dir / "trial_001",
+        {"my_metric": 7.0},
+        case_id="trial",
+    )
+
+    result = tools.evaluate_batch_trials(
+        str(results_dir),
+        assertions=[{"metric": "my_metric", "operator": "lt", "threshold": 10.0}],
+    )
+    assert result["total_trials"] == 1
+    assert result["success_rate"] == 1.0
+
+
+def test_evaluate_batch_trials_ci_passed(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    _create_report(
+        results_dir / "trial_001",
+        {
+            "grip_center_error_mm": 10.0,
+            "pinch_gap_error_mm": 5.0,
+            "pinch_elevation_deg": 3.0,
+            "index_middle_vertical_deg": 5.0,
+        },
+    )
+
+    result = tools.evaluate_batch_trials(
+        str(results_dir),
+        min_success_rate=0.8,
+    )
+    assert result["ci_passed"] is True
+    assert result["min_success_rate"] == 0.8
+
+
+def test_evaluate_batch_trials_ci_failed(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    # Failing trial
+    _create_report(results_dir / "trial_001", {"grip_center_error_mm": 100.0})
+
+    result = tools.evaluate_batch_trials(
+        str(results_dir),
+        min_success_rate=0.8,
+    )
+    assert result["ci_passed"] is False
+
+
+def test_evaluate_batch_trials_no_ci_threshold(tools, tmp_path):
+    results_dir = tmp_path / "trials"
+    _create_report(results_dir / "trial_001", {"grip_center_error_mm": 10.0})
+
+    result = tools.evaluate_batch_trials(str(results_dir))
+    assert "ci_passed" not in result
+    assert "min_success_rate" not in result


### PR DESCRIPTION
Closes #142

## Summary

- Adds batch evaluation tool to the MCP server, connecting it to the `evaluate` module for pass/fail results
- Adds base64 screenshot support via MCP tools
- Exports new tools from `src/roboharness/mcp/__init__.py`

## Changes

- `src/roboharness/mcp/tools.py`: New `batch_evaluate` tool and `capture_screenshot_base64` tool (+133 lines)
- `src/roboharness/mcp/server.py`: Register new tools
- `src/roboharness/mcp/__init__.py`: Export new symbols
- `tests/test_mcp_tools.py`: Comprehensive tests for new tools (+172 lines)
- `tests/test_mcp_server.py`: Server integration tests (+25 lines)

## Verification

- All 390 tests pass
- Ruff lint and format checks pass
- No merge conflicts with main