### PR TITLE
feat: #147 — create HuggingFace Space with demo reports

### DIFF
--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -1,0 +1,66 @@
+name: Sync to HuggingFace Space
+
+on:
+  workflow_run:
+    workflows: ["Deploy Visual Report to GitHub Pages"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: hf-space
+
+      # When triggered by the Pages workflow, download its build artifact
+      - name: Download site artifact
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          name: site-content
+          path: _site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # When triggered manually, fetch the published site
+      - name: Fetch published site
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p _site/grasp _site/g1-reach _site/g1-loco _site/g1-native _site/sonic
+          BASE=https://miaodx.com/roboharness
+          curl -fsSL "$BASE/"           -o _site/index.html
+          curl -fsSL "$BASE/grasp/"     -o _site/grasp/index.html
+          curl -fsSL "$BASE/g1-reach/"  -o _site/g1-reach/index.html
+          curl -fsSL "$BASE/g1-loco/"   -o _site/g1-loco/index.html
+          curl -fsSL "$BASE/g1-native/" -o _site/g1-native/index.html
+          curl -fsSL "$BASE/sonic/"     -o _site/sonic/index.html
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install huggingface_hub
+        run: pip install huggingface_hub
+
+      - name: Add Space metadata
+        run: cp hf-space/README.md _site/README.md
+
+      - name: Push to HuggingFace Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python -c "
+          from huggingface_hub import HfApi
+          api = HfApi()
+          api.upload_folder(
+              folder_path='_site',
+              repo_id='MiaoDX/roboharness-demo',
+              repo_type='space',
+          )
+          "

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -122,6 +122,13 @@ jobs:
         with:
           path: _site
 
+      - name: Upload site content for downstream workflows
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-content
+          path: _site
+
   deploy:
     needs: build
     if: ${{ !cancelled() }}

--- a/hf-space/README.md
+++ b/hf-space/README.md
@@ -1,0 +1,23 @@
+---
+title: Roboharness Demo Reports
+emoji: "\U0001F916"
+colorFrom: blue
+colorTo: indigo
+sdk: static
+pinned: false
+license: mit
+---
+
+# Roboharness: Visual Testing Harness for AI Coding Agents in Robot Simulation
+
+Interactive visual reports auto-generated from CI. Each demo runs headless in GitHub Actions using MuJoCo + OSMesa and captures multi-view checkpoint screenshots.
+
+**Demos included:**
+
+- **MuJoCo Grasp** -- Scripted 2-finger gripper grasping a cube with Meshcat 3D scenes
+- **G1 WBC Reach** -- Unitree G1 whole-body control reaching with Pinocchio + Pink
+- **G1 Locomotion** -- GR00T RL stand/walk/stop using ONNX locomotion policies
+- **G1 Native LeRobot** -- Official `make_env()` factory integration
+- **SONIC Motion Tracking** -- NVIDIA GEAR-SONIC encoder+decoder MoCap pipeline
+
+[GitHub Repository](https://github.com/MiaoDX/roboharness) | [GitHub Pages (primary)](https://miaodx.com/roboharness/)


### PR DESCRIPTION
## Summary

- Add HuggingFace Space deployment workflow triggered after GitHub Pages builds
- Upload CI-generated HTML reports to `MiaoDX/roboharness-demo` static Space
- Include Space metadata README with all five demo descriptions (grasp, g1-reach, g1-loco, g1-native, sonic)

Closes #147

## Changes

- `.github/workflows/hf-space.yml`: New workflow syncing site content to HF Space (triggered by Pages workflow or manual dispatch)
- `.github/workflows/pages.yml`: Upload site artifact for downstream workflow consumption
- `hf-space/README.md`: Space metadata (static SDK, MIT license) and project description

## Test plan

- [x] All 401 tests pass
- [x] Ruff lint + format clean
- [x] No merge conflicts with main
- [ ] `HF_TOKEN` secret must be configured in repo settings for the workflow to run
- [ ] Workflow triggers on Pages deployment completion

https://claude.ai/code/session_01Hw5BBT1TpNn64ESLVoab1W