### PR TITLE
feat: #74 — add VectorEnvAdapter for LeRobot make_env() integration

### DIFF
--- a/examples/lerobot_g1_native.py
+++ b/examples/lerobot_g1_native.py
@@ -42,7 +42,7 @@ import gymnasium as gym  # noqa: TC002 — used at runtime inside create_native_
 import numpy as np
 
 from roboharness.core.protocol import TaskPhase, TaskProtocol
-from roboharness.wrappers import RobotHarnessWrapper
+from roboharness.wrappers import RobotHarnessWrapper, VectorEnvAdapter
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -110,14 +110,18 @@ def create_native_env(
     *,
     n_envs: int = 1,
 ) -> gym.Env:
-    """Create a LeRobot environment by importing the hub env module directly.
+    """Create a LeRobot environment, preferring the official ``make_env()`` factory.
 
-    We import the hub's ``env.py`` directly rather than going through
-    lerobot's ``make_env()`` factory, which wraps in ``SyncVectorEnv``
-    and breaks due to an obs-space shape mismatch in the upstream env.
+    Strategy (in order):
+      1. Try LeRobot's ``make_env()`` — wraps the hub env in ``SyncVectorEnv``.
+         We unwrap the batch dimension via ``VectorEnvAdapter`` so downstream
+         wrappers see a standard single-env interface.
+      2. Fall back to importing the hub's ``env.py`` directly (works without
+         the full LeRobot install; avoids the ``SyncVectorEnv`` obs-space
+         mismatch that the upstream env has).
     """
     try:
-        from huggingface_hub import snapshot_download
+        from huggingface_hub import snapshot_download  # noqa: F401 — used below
     except ImportError:
         print(
             "ERROR: huggingface_hub is required for native integration.\n"
@@ -128,9 +132,49 @@ def create_native_env(
     # Patch config for headless CI environments before importing env module
     _patch_config_for_headless(env_id)
 
-    # Import the hub env module directly to avoid lerobot's VectorEnv wrapping.
-    # lerobot's make_env() wraps in SyncVectorEnv which breaks when the hub env's
-    # observation_space shape doesn't match actual obs (upstream bug in g1 env).
+    env = _try_lerobot_make_env(env_id, n_envs=n_envs)
+    if env is None:
+        env = _fallback_hub_make_env(env_id, n_envs=n_envs)
+
+    # Add MuJoCo rendering capability — the hub env has a MuJoCo model but
+    # doesn't expose render_camera(), so the wrapper can't capture screenshots.
+    _add_mujoco_rendering(env)
+
+    print(f"      Env type: {type(env).__name__}")
+    print(f"      Obs space (declared): {env.observation_space}")
+    print(f"      Act space: {env.action_space}")
+
+    return env
+
+
+def _try_lerobot_make_env(env_id: str, *, n_envs: int = 1) -> gym.Env | None:
+    """Try creating the env via LeRobot's official ``make_env()`` factory.
+
+    Returns a ``VectorEnvAdapter``-wrapped env on success, or ``None`` if
+    LeRobot is not installed or ``make_env()`` fails.
+    """
+    try:
+        from lerobot.common.envs.factory import make_env  # type: ignore[import-untyped]
+    except ImportError:
+        print("      LeRobot not installed — falling back to hub env import")
+        return None
+
+    try:
+        vec_env = make_env(env_id, n_envs=n_envs)
+    except Exception as exc:
+        print(f"      LeRobot make_env() failed ({exc}) — falling back to hub env import")
+        return None
+
+    # make_env() wraps in SyncVectorEnv; adapt to standard gym.Env.
+    env = VectorEnvAdapter(vec_env)
+    print("      Created via LeRobot make_env() + VectorEnvAdapter")
+    return env
+
+
+def _fallback_hub_make_env(env_id: str, *, n_envs: int = 1) -> gym.Env:
+    """Import the hub's ``env.py`` directly (no LeRobot dependency)."""
+    from huggingface_hub import snapshot_download
+
     repo_dir = Path(snapshot_download(env_id, repo_type="model"))
     sys.path.insert(0, str(repo_dir))
     try:
@@ -145,14 +189,7 @@ def create_native_env(
     # floating_base_acc being 6-D not 3-D) is handled automatically by
     # RobotHarnessWrapper(auto_fix_obs_space=True). See issue #110.
 
-    # Add MuJoCo rendering capability — the hub env has a MuJoCo model but
-    # doesn't expose render_camera(), so the wrapper can't capture screenshots.
-    _add_mujoco_rendering(env)
-
-    print(f"      Env type: {type(env).__name__}")
-    print(f"      Obs space (declared): {env.observation_space}")
-    print(f"      Act space: {env.action_space}")
-
+    print("      Created via direct hub env import (fallback)")
     return env
 
 

--- a/src/roboharness/robots/unitree_g1/locomotion.py
+++ b/src/roboharness/robots/unitree_g1/locomotion.py
@@ -259,7 +259,9 @@ class GrootLocomotionController:
         self._action[:] = output[0].flatten()[:NUM_LOWER_BODY_JOINTS]
 
         # Decode action → joint position targets
-        target = GROOT_DEFAULT_ANGLES[:NUM_LOWER_BODY_JOINTS] + self._action * ACTION_SCALE
+        target: np.ndarray = (
+            GROOT_DEFAULT_ANGLES[:NUM_LOWER_BODY_JOINTS] + self._action * ACTION_SCALE
+        )
         return target
 
     def reset(self) -> None:
@@ -390,7 +392,7 @@ class HolosomaLocomotionController:
         self._action[:] = output[0].flatten()[:NUM_BODY_JOINTS]
 
         # Decode action → joint position targets
-        target = HOLOSOMA_DEFAULT_ANGLES + self._action * HOLOSOMA_ACTION_SCALE
+        target: np.ndarray = HOLOSOMA_DEFAULT_ANGLES + self._action * HOLOSOMA_ACTION_SCALE
         return target
 
     def reset(self) -> None:

--- a/src/roboharness/wrappers/__init__.py
+++ b/src/roboharness/wrappers/__init__.py
@@ -1,5 +1,6 @@
 """Gymnasium wrappers for Roboharness."""
 
 from roboharness.wrappers.gymnasium_wrapper import RobotHarnessWrapper
+from roboharness.wrappers.vector_env_adapter import VectorEnvAdapter
 
-__all__ = ["RobotHarnessWrapper"]
+__all__ = ["RobotHarnessWrapper", "VectorEnvAdapter"]

--- a/src/roboharness/wrappers/gymnasium_wrapper.py
+++ b/src/roboharness/wrappers/gymnasium_wrapper.py
@@ -108,8 +108,9 @@ def _capture_frame_from_env(
         if capability == MultiCameraCapability.RENDER_CAMERA:
             # Try env first, then unwrapped
             for target in (env, getattr(env, "unwrapped", None)):
-                if target is not None and callable(getattr(target, "render_camera", None)):
-                    frame = target.render_camera(camera_name)
+                render_fn = getattr(target, "render_camera", None)
+                if target is not None and callable(render_fn):
+                    frame = render_fn(camera_name)
                     return _to_numpy_rgb(frame)
 
         if capability == MultiCameraCapability.ISAAC_TILED:
@@ -286,14 +287,15 @@ class RobotHarnessWrapper(Wrapper):  # type: ignore[type-arg]
         """Step environment. Captures screenshots at checkpoint steps."""
         obs, reward, terminated, truncated, info = self.env.step(action)
         self._step_count += 1
+        reward_f = _to_float(reward)
 
         # Check if we hit a checkpoint
         if self._step_count in self._checkpoints:
             cp_name = self._checkpoints[self._step_count]
-            capture_info = self._capture_checkpoint(cp_name, obs, reward, info)
+            capture_info = self._capture_checkpoint(cp_name, obs, reward_f, info)
             info["checkpoint"] = capture_info
 
-        return obs, reward, terminated, truncated, info
+        return obs, reward_f, terminated, truncated, info
 
     @property
     def active_protocol(self) -> TaskProtocol | None:

--- a/src/roboharness/wrappers/vector_env_adapter.py
+++ b/src/roboharness/wrappers/vector_env_adapter.py
@@ -1,0 +1,171 @@
+"""VectorEnvAdapter — adapts a single-instance VectorEnv to standard gym.Env.
+
+LeRobot's ``make_env()`` factory wraps environments in ``SyncVectorEnv`` even
+when ``n_envs=1``.  This causes incompatibilities with wrappers (like
+``RobotHarnessWrapper``) that expect a standard ``gym.Env`` interface, because
+observations gain a batch dimension, ``step()`` returns arrays instead of
+scalars, and the ``unwrapped`` chain breaks.
+
+``VectorEnvAdapter`` fixes this by squeezing the batch dimension so downstream
+code sees a standard single-env interface.
+
+Usage::
+
+    from lerobot.envs.factory import make_env
+    from roboharness.wrappers import VectorEnvAdapter, RobotHarnessWrapper
+
+    vec_env = make_env("lerobot/unitree-g1-mujoco", n_envs=1)
+    env = VectorEnvAdapter(vec_env)
+    env = RobotHarnessWrapper(env, ...)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+try:
+    import gymnasium as gym
+except ImportError:
+    import gym  # type: ignore[no-redef]
+
+logger = logging.getLogger(__name__)
+
+
+class VectorEnvAdapter(gym.Env):  # type: ignore[type-arg]
+    """Adapts a ``VectorEnv`` (``num_envs=1``) to a standard ``gym.Env``.
+
+    Parameters
+    ----------
+    vec_env:
+        A Gymnasium ``VectorEnv`` instance with exactly one sub-environment.
+        Typically the return value of LeRobot's ``make_env(..., n_envs=1)``.
+    """
+
+    def __init__(self, vec_env: gym.vector.VectorEnv) -> None:  # type: ignore[name-defined]
+        num_envs: int = getattr(vec_env, "num_envs", 0)
+        if num_envs != 1:
+            msg = (
+                f"VectorEnvAdapter requires num_envs=1, got {num_envs}. "
+                "Pass a VectorEnv wrapping exactly one sub-environment."
+            )
+            raise ValueError(msg)
+
+        self._vec_env = vec_env
+
+        # Expose single-env spaces (without the batch dimension).
+        self.observation_space = vec_env.single_observation_space
+        self.action_space = vec_env.single_action_space
+
+        # Preserve env metadata expected by Gymnasium wrappers.
+        self.metadata: dict[str, Any] = getattr(vec_env, "metadata", {})
+        self.render_mode: str | None = getattr(vec_env, "render_mode", None)
+
+        # Cache a reference to the underlying single env for attribute proxying.
+        # SyncVectorEnv stores sub-envs in .envs; AsyncVectorEnv doesn't expose
+        # them, so this may be None.
+        envs = getattr(vec_env, "envs", None)
+        self._single_env: gym.Env | None = envs[0] if envs else None  # type: ignore[index,type-arg]
+
+    # ------------------------------------------------------------------
+    # gym.Env interface
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        obs, info = self._vec_env.reset(seed=seed, options=options)
+        return _squeeze_obs(obs), _squeeze_info(info)
+
+    def step(self, action: np.ndarray) -> tuple[Any, float, bool, bool, dict[str, Any]]:
+        # VectorEnv.step() expects shape (num_envs, *action_shape).
+        batched = np.expand_dims(np.asarray(action), axis=0)
+        obs, rewards, terminateds, truncateds, info = self._vec_env.step(batched)
+
+        return (
+            _squeeze_obs(obs),
+            float(rewards[0]),
+            bool(terminateds[0]),
+            bool(truncateds[0]),
+            _squeeze_info(info),
+        )
+
+    def render(self) -> np.ndarray | None:
+        frames = self._vec_env.render()
+        if frames is None:
+            return None
+        # SyncVectorEnv.render() returns a tuple of frames (one per env)
+        # or a stacked ndarray with shape (num_envs, H, W, C).
+        if isinstance(frames, (tuple, list)) and len(frames) >= 1:
+            return frames[0]
+        if isinstance(frames, np.ndarray) and frames.ndim == 4:
+            return frames[0]
+        return frames
+
+    def close(self) -> None:
+        self._vec_env.close()
+
+    # ------------------------------------------------------------------
+    # Attribute proxying
+    # ------------------------------------------------------------------
+
+    @property
+    def unwrapped(self) -> gym.Env:  # type: ignore[type-arg]
+        """Return the underlying single env's ``unwrapped`` (bypassing VectorEnv)."""
+        if self._single_env is not None:
+            return getattr(self._single_env, "unwrapped", self._single_env)
+        return self  # type: ignore[return-value]
+
+    def __getattr__(self, name: str) -> Any:
+        """Proxy attribute access to the underlying single env.
+
+        This lets callers access env-specific attributes (e.g. ``mj_model``,
+        ``render_camera``) that are defined on the sub-env but not on the
+        VectorEnv wrapper.
+        """
+        # Avoid infinite recursion for private / dunder attributes.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        single = self.__dict__.get("_single_env")
+        if single is not None:
+            return getattr(single, name)
+        raise AttributeError(f"'{type(self).__name__}' has no attribute '{name}'")
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _squeeze_obs(obs: Any) -> Any:
+    """Remove the batch dimension from an observation."""
+    if isinstance(obs, dict):
+        return {k: v[0] if hasattr(v, "__getitem__") else v for k, v in obs.items()}
+    if hasattr(obs, "__getitem__"):
+        return obs[0]
+    return obs
+
+
+def _squeeze_info(info: dict[str, Any]) -> dict[str, Any]:
+    """Remove the batch dimension from a VectorEnv info dict.
+
+    Gymnasium's ``SyncVectorEnv`` returns info values as lists or arrays
+    with length ``num_envs``.  For ``num_envs=1`` we extract the single
+    element.
+    """
+    if not info:
+        return {}
+    squeezed: dict[str, Any] = {}
+    for key, val in info.items():
+        if (isinstance(val, np.ndarray) and val.ndim >= 1 and val.shape[0] == 1) or (
+            isinstance(val, (list, tuple)) and len(val) == 1
+        ):
+            squeezed[key] = val[0]
+        else:
+            squeezed[key] = val
+    return squeezed

--- a/tests/test_vector_env_adapter.py
+++ b/tests/test_vector_env_adapter.py
@@ -1,0 +1,372 @@
+"""Tests for VectorEnvAdapter — validates batch-squeezing from VectorEnv to gym.Env.
+
+Uses real Gymnasium SyncVectorEnv wrapping lightweight envs. No mocks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import numpy as np
+import pytest
+
+gym = pytest.importorskip("gymnasium", reason="gymnasium not installed")
+
+from gymnasium import spaces  # noqa: E402
+
+from roboharness.wrappers import RobotHarnessWrapper, VectorEnvAdapter  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Lightweight test environments
+# ---------------------------------------------------------------------------
+
+
+class FlatEnv(gym.Env):
+    """Simple env with flat Box obs/act spaces (robot-like dimensions)."""
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": ["rgb_array"], "render_fps": 50}
+
+    def __init__(self, render_mode: str = "rgb_array"):
+        super().__init__()
+        self.render_mode = render_mode
+        self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(12,), dtype=np.float64)
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(4,), dtype=np.float64)
+        self._step_count = 0
+        self.custom_attr = "hello"
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[np.ndarray, dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        self._step_count = 0
+        return np.zeros(12, dtype=np.float64), {}
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict[str, Any]]:
+        self._step_count += 1
+        obs = np.ones(12, dtype=np.float64) * self._step_count * 0.1
+        terminated = self._step_count >= 100
+        return obs, 1.5, terminated, False, {"sim_time": self._step_count * 0.02}
+
+    def render(self) -> np.ndarray:
+        return np.full((64, 64, 3), self._step_count, dtype=np.uint8)
+
+
+class DictObsEnv(gym.Env):
+    """Env with Dict observation space."""
+
+    metadata: ClassVar[dict[str, Any]] = {"render_modes": ["rgb_array"], "render_fps": 50}
+
+    def __init__(self, render_mode: str = "rgb_array"):
+        super().__init__()
+        self.render_mode = render_mode
+        self.observation_space = spaces.Dict(
+            {
+                "joints": spaces.Box(low=-np.pi, high=np.pi, shape=(6,), dtype=np.float32),
+                "image": spaces.Box(low=0, high=255, shape=(32, 32, 3), dtype=np.uint8),
+            }
+        )
+        self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype=np.float32)
+        self._step_count = 0
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        super().reset(seed=seed, options=options)
+        self._step_count = 0
+        return {
+            "joints": np.zeros(6, dtype=np.float32),
+            "image": np.zeros((32, 32, 3), dtype=np.uint8),
+        }, {}
+
+    def step(
+        self, action: np.ndarray
+    ) -> tuple[dict[str, np.ndarray], float, bool, bool, dict[str, Any]]:
+        self._step_count += 1
+        return (
+            {
+                "joints": np.ones(6, dtype=np.float32) * 0.5,
+                "image": np.ones((32, 32, 3), dtype=np.uint8) * 100,
+            },
+            2.0,
+            False,
+            False,
+            {},
+        )
+
+    def render(self) -> np.ndarray:
+        return np.zeros((32, 32, 3), dtype=np.uint8)
+
+
+class CameraEnv(FlatEnv):
+    """FlatEnv with render_camera support for multi-camera testing."""
+
+    def __init__(self, render_mode: str = "rgb_array"):
+        super().__init__(render_mode=render_mode)
+        self.cameras = ["front", "side"]
+
+    def render_camera(self, camera_name: str) -> np.ndarray:
+        if camera_name not in self.cameras:
+            raise ValueError(f"Unknown camera: {camera_name}")
+        return np.full((64, 64, 3), self.cameras.index(camera_name) * 50, dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_vec_env(env_cls: type, **kwargs: Any) -> gym.vector.SyncVectorEnv:
+    """Create a SyncVectorEnv with num_envs=1."""
+    return gym.vector.SyncVectorEnv([lambda: env_cls(**kwargs)])
+
+
+# ---------------------------------------------------------------------------
+# Tests: construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """VectorEnvAdapter construction and validation."""
+
+    def test_accepts_sync_vector_env(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        assert adapter.observation_space.shape == (12,)
+        assert adapter.action_space.shape == (4,)
+        adapter.close()
+
+    def test_rejects_multi_env(self):
+        vec = gym.vector.SyncVectorEnv([lambda: FlatEnv(), lambda: FlatEnv()])
+        with pytest.raises(ValueError, match="num_envs=1"):
+            VectorEnvAdapter(vec)
+        vec.close()
+
+    def test_spaces_match_single_env(self):
+        base = FlatEnv()
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+
+        assert adapter.observation_space == base.observation_space
+        assert adapter.action_space == base.action_space
+        adapter.close()
+
+    def test_dict_obs_spaces(self):
+        vec = _make_vec_env(DictObsEnv)
+        adapter = VectorEnvAdapter(vec)
+
+        assert isinstance(adapter.observation_space, spaces.Dict)
+        assert "joints" in adapter.observation_space.spaces
+        assert adapter.observation_space["joints"].shape == (6,)
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset / step
+# ---------------------------------------------------------------------------
+
+
+class TestResetStep:
+    """Core gym.Env interface via VectorEnvAdapter."""
+
+    def test_reset_returns_unbatched_obs(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+
+        obs, _info = adapter.reset()
+        assert isinstance(obs, np.ndarray)
+        assert obs.shape == (12,)
+        np.testing.assert_array_equal(obs, np.zeros(12))
+        adapter.close()
+
+    def test_step_returns_scalar_reward(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        adapter.reset()
+
+        obs, reward, terminated, truncated, _info = adapter.step(np.zeros(4))
+
+        assert obs.shape == (12,)
+        assert reward == 1.5
+        assert isinstance(reward, float)
+        assert isinstance(terminated, bool)
+        assert isinstance(truncated, bool)
+        assert not terminated
+        assert not truncated
+        adapter.close()
+
+    def test_obs_values_match_underlying_env(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        adapter.reset()
+
+        obs, _, _, _, _ = adapter.step(np.zeros(4))
+        # FlatEnv step 1: obs = ones(12) * 0.1
+        np.testing.assert_allclose(obs, np.ones(12) * 0.1)
+        adapter.close()
+
+    def test_terminated_propagates(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        adapter.reset()
+
+        # FlatEnv terminates at step 100
+        for _i in range(100):
+            _, _, terminated, _, _ = adapter.step(np.zeros(4))
+        assert terminated
+        adapter.close()
+
+    def test_dict_obs_squeezed(self):
+        vec = _make_vec_env(DictObsEnv)
+        adapter = VectorEnvAdapter(vec)
+
+        obs, _ = adapter.reset()
+        assert isinstance(obs, dict)
+        assert obs["joints"].shape == (6,)
+        assert obs["image"].shape == (32, 32, 3)
+
+        obs, reward, _, _, _ = adapter.step(np.zeros(6, dtype=np.float32))
+        assert obs["joints"].shape == (6,)
+        assert reward == 2.0
+        adapter.close()
+
+    def test_info_squeezed(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        adapter.reset()
+
+        _, _, _, _, info = adapter.step(np.zeros(4))
+        # FlatEnv returns sim_time as a float, not array
+        if "sim_time" in info:
+            assert isinstance(info["sim_time"], (int, float, np.floating))
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: render
+# ---------------------------------------------------------------------------
+
+
+class TestRender:
+    """Render pass-through."""
+
+    def test_render_returns_single_frame(self):
+        vec = _make_vec_env(FlatEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+        adapter.reset()
+
+        frame = adapter.render()
+        assert isinstance(frame, np.ndarray)
+        # Should be 3D (H, W, C), not 4D (batch, H, W, C)
+        assert frame.ndim == 3
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: attribute proxying
+# ---------------------------------------------------------------------------
+
+
+class TestAttributeProxy:
+    """Attribute access proxied to the underlying single env."""
+
+    def test_custom_attr(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        assert adapter.custom_attr == "hello"
+        adapter.close()
+
+    def test_unwrapped_returns_single_env(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        assert isinstance(adapter.unwrapped, FlatEnv)
+        adapter.close()
+
+    def test_render_camera_proxied(self):
+        vec = _make_vec_env(CameraEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+        assert hasattr(adapter.unwrapped, "render_camera")
+        frame = adapter.unwrapped.render_camera("front")
+        assert frame.shape == (64, 64, 3)
+        adapter.close()
+
+    def test_cameras_proxied(self):
+        vec = _make_vec_env(CameraEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+        assert adapter.unwrapped.cameras == ["front", "side"]
+        adapter.close()
+
+    def test_missing_attr_raises(self):
+        vec = _make_vec_env(FlatEnv)
+        adapter = VectorEnvAdapter(vec)
+        with pytest.raises(AttributeError):
+            _ = adapter.nonexistent_attribute
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: integration with RobotHarnessWrapper
+# ---------------------------------------------------------------------------
+
+
+class TestWrapperIntegration:
+    """VectorEnvAdapter works as a drop-in for RobotHarnessWrapper."""
+
+    def test_checkpoint_through_adapter(self, tmp_path):
+        vec = _make_vec_env(FlatEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp1", "step": 2}, {"name": "cp2", "step": 5}],
+            output_dir=tmp_path,
+            task_name="adapter_test",
+        )
+        wrapped.reset()
+
+        captured = []
+        for _ in range(5):
+            _, _, _, _, info = wrapped.step(np.zeros(4))
+            if "checkpoint" in info:
+                captured.append(info["checkpoint"]["name"])
+
+        assert captured == ["cp1", "cp2"]
+        wrapped.close()
+
+    def test_multi_camera_through_adapter(self, tmp_path):
+        vec = _make_vec_env(CameraEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 1}],
+            cameras=["front", "side"],
+            output_dir=tmp_path,
+            task_name="multicam_test",
+        )
+        wrapped.reset()
+        wrapped.step(np.zeros(4))
+
+        capture_dir = tmp_path / "multicam_test" / "trial_001" / "cp"
+        image_files = sorted(f.name for f in capture_dir.glob("*_rgb.*"))
+        assert len(image_files) == 2
+        wrapped.close()
+
+    def test_dict_obs_through_adapter(self, tmp_path):
+        vec = _make_vec_env(DictObsEnv, render_mode="rgb_array")
+        adapter = VectorEnvAdapter(vec)
+
+        wrapped = RobotHarnessWrapper(
+            adapter,
+            checkpoints=[{"name": "cp", "step": 1}],
+            output_dir=tmp_path,
+            task_name="dict_test",
+        )
+        obs, _ = wrapped.reset()
+        assert isinstance(obs, dict)
+        assert obs["joints"].shape == (6,)
+
+        obs, reward, _, _, info = wrapped.step(np.zeros(6, dtype=np.float32))
+        assert isinstance(obs, dict)
+        assert reward == 2.0
+        assert "checkpoint" in info
+        wrapped.close()


### PR DESCRIPTION
## Summary

- Add `VectorEnvAdapter` that adapts a single-instance `VectorEnv` (from LeRobot's `make_env()`) to a standard `gym.Env` interface, squeezing the batch dimension and proxying attributes from the underlying sub-env
- Update `lerobot_g1_native.py` to try LeRobot's official `make_env()` + `VectorEnvAdapter` first, falling back to direct hub env import when LeRobot is not installed
- Add 19 tests covering construction, reset/step, render, attribute proxying, and integration with `RobotHarnessWrapper`
- Export `VectorEnvAdapter` from `roboharness.wrappers`

Closes #74

## Test plan

- [x] 19 new tests pass for VectorEnvAdapter (construction, reset/step, render, attribute proxy, wrapper integration)
- [x] All 420 existing tests still pass
- [x] Coverage at 95.38% (above 90% threshold)
- [x] ruff check, ruff format, mypy all pass

https://claude.ai/code/session_018BZ25gFhSDVpiNiQ2wc9H3