### PR TITLE
docs: #166 — Document development workflow: web sessions vs local GPU CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,11 +80,9 @@ The project uses a tiered development workflow. Choose the right environment for
 | **Claude Code CLI + local GPU** | Yes | Demo debugging, visual QA, ONNX/rendering, locomotion controllers |
 | **CI (GitHub Actions + Cirun)** | CPU + T4 | Automated gating, regression detection |
 
-**Use web sessions** for anything that doesn't need GPU or real rendering: writing/refactoring `src/roboharness/`, adding tests with mocked backends, fixing lint/type/CI issues, updating docs.
+**Rule of thumb:** if you need to _see_ what the robot is doing, use local CLI + GPU. If you're writing logic and tests, use web.
 
-**Use local CLI + GPU** when you need to see what the robot is doing: debugging locomotion controllers (GR00T, SONIC), fixing visual report rendering, developing new backends or camera configs, Isaac Lab integration.
-
-Local GPU setup: run `scripts/gpu-dev-setup.sh` or see `docs/development-workflow.md` for manual steps.
+Local GPU setup: run `scripts/gpu-dev-setup.sh` or see `docs/development-workflow.md` for manual steps. Use `make check-gpu` to verify the setup, `make demos` to run all demos.
 
 ## Tools & environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,22 @@ Skipping step 2 leads to guessing — which wastes time and misses the real issu
 - Isaac Lab integration (`examples/isaac_lab_integration.py`) **requires NVIDIA RTX GPU** — cannot run in current CPU-only CI. Tests in `test_isaac_lab_compat.py` use mock envs to validate on CPU.
 - Version is defined in both `pyproject.toml` and `src/roboharness/__init__.py` — keep them in sync.
 
+## Development environments
+
+The project uses a tiered development workflow. Choose the right environment for the task:
+
+| Environment | GPU | Best for |
+|-------------|-----|----------|
+| **claude.ai/code (web)** | No | Core logic, tests, refactors, CI config, docs |
+| **Claude Code CLI + local GPU** | Yes | Demo debugging, visual QA, ONNX/rendering, locomotion controllers |
+| **CI (GitHub Actions + Cirun)** | CPU + T4 | Automated gating, regression detection |
+
+**Use web sessions** for anything that doesn't need GPU or real rendering: writing/refactoring `src/roboharness/`, adding tests with mocked backends, fixing lint/type/CI issues, updating docs.
+
+**Use local CLI + GPU** when you need to see what the robot is doing: debugging locomotion controllers (GR00T, SONIC), fixing visual report rendering, developing new backends or camera configs, Isaac Lab integration.
+
+Local GPU setup: run `scripts/gpu-dev-setup.sh` or see `docs/development-workflow.md` for manual steps.
+
 ## Tools & environment
 
 - IMPORTANT: GitHub MCP tools are available (prefixed `mcp__github__`). Use them for all GitHub interactions (issues, PRs, comments). In **cloud/web environments** (Claude Code on the web), do NOT use `gh` CLI — it cannot be authorized; always use GitHub MCP tools. If an MCP tool call fails due to temporary unavailability, wait ~2 minutes and retry. In **local environments** (CLI/IDE), `gh` CLI is available and can be used normally.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+.PHONY: lint format typecheck test check-all check-gpu \
+       demo-grasp demo-sonic demo-g1 demo-g1-native demo-wbc demos
+
+# --- Development (CPU, works in web sessions) ---
+
+lint:
+	ruff check .
+	ruff format --check .
+
+format:
+	ruff format .
+	ruff check --fix .
+
+typecheck:
+	mypy src/
+
+test:
+	pytest
+
+test-quick:
+	pytest --no-cov -x
+
+check-all: lint typecheck test
+
+# --- GPU environment verification ---
+
+check-gpu:
+	@python3 -c "import mujoco; print('mujoco: OK')"
+	@python3 -c "import onnxruntime as ort; print('onnxruntime:', ort.get_device())"
+	@nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null \
+		|| echo "nvidia-smi: not available (CPU-only environment)"
+
+# --- Demos (require GPU or MUJOCO_GL=osmesa for headless) ---
+
+MUJOCO_GL ?= osmesa
+
+demo-grasp:
+	MUJOCO_GL=$(MUJOCO_GL) python examples/mujoco_grasp.py --report
+
+demo-sonic:
+	MUJOCO_GL=$(MUJOCO_GL) python examples/sonic_locomotion.py --report
+
+demo-g1:
+	MUJOCO_GL=$(MUJOCO_GL) python examples/lerobot_g1.py --report
+
+demo-g1-native:
+	MUJOCO_GL=$(MUJOCO_GL) python examples/lerobot_g1_native.py --report
+
+demo-wbc:
+	MUJOCO_GL=$(MUJOCO_GL) python examples/g1_wbc_reach.py --report
+
+demos: demo-grasp demo-wbc demo-g1 demo-sonic
+	@echo "All demos complete. Check output directories for reports."

--- a/scripts/gpu-dev-setup.sh
+++ b/scripts/gpu-dev-setup.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# gpu-dev-setup.sh
+#
+# Sets up a local GPU development environment for roboharness.
+# Run this on any Linux machine with an NVIDIA GPU to get started
+# with GPU-dependent tasks (demo debugging, visual QA, ONNX/rendering).
+#
+# Prerequisites:
+#   - NVIDIA GPU with drivers installed (nvidia-smi should work)
+#   - Python 3.10+ (python3 or conda/venv)
+#   - pip
+#
+# Usage:
+#   ./scripts/gpu-dev-setup.sh
+#
+# Environment variables:
+#   CUDA_VERSION  - PyTorch CUDA version (default: cu121)
+#   PYTHON        - Python executable (default: python3)
+#   SKIP_TORCH    - Set to 1 to skip PyTorch installation
+#
+
+set -euo pipefail
+
+CUDA_VERSION="${CUDA_VERSION:-cu121}"
+PYTHON="${PYTHON:-python3}"
+SKIP_TORCH="${SKIP_TORCH:-0}"
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ─── Preflight checks ───────────────────────────────────────────────────────
+info "Checking prerequisites..."
+
+if ! command -v nvidia-smi &>/dev/null; then
+    error "nvidia-smi not found. Install NVIDIA drivers first."
+    exit 1
+fi
+
+if ! nvidia-smi &>/dev/null; then
+    error "nvidia-smi failed. GPU drivers may not be loaded."
+    exit 1
+fi
+
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)
+info "GPU detected: ${GPU_NAME}"
+
+if ! command -v "${PYTHON}" &>/dev/null; then
+    error "${PYTHON} not found. Install Python 3.10+ first."
+    exit 1
+fi
+
+PY_VERSION=$("${PYTHON}" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+PY_MAJOR=$("${PYTHON}" -c 'import sys; print(sys.version_info.major)')
+PY_MINOR=$("${PYTHON}" -c 'import sys; print(sys.version_info.minor)')
+
+if [ "${PY_MAJOR}" -lt 3 ] || { [ "${PY_MAJOR}" -eq 3 ] && [ "${PY_MINOR}" -lt 10 ]; }; then
+    error "Python 3.10+ required, found ${PY_VERSION}"
+    exit 1
+fi
+
+info "Python ${PY_VERSION} OK"
+
+# ─── Install roboharness with all optional deps ─────────────────────────────
+info "Installing roboharness with demo + dev dependencies..."
+"${PYTHON}" -m pip install -e ".[demo,dev]"
+
+# ─── Install PyTorch with CUDA ──────────────────────────────────────────────
+if [ "${SKIP_TORCH}" = "1" ]; then
+    warn "Skipping PyTorch installation (SKIP_TORCH=1)"
+else
+    info "Installing PyTorch with CUDA (${CUDA_VERSION})..."
+    "${PYTHON}" -m pip install torch --index-url "https://download.pytorch.org/whl/${CUDA_VERSION}"
+fi
+
+# ─── Verify GPU rendering ───────────────────────────────────────────────────
+info "Verifying MuJoCo GPU rendering..."
+if MUJOCO_GL=egl "${PYTHON}" -c "import mujoco; print('MuJoCo OK')" 2>/dev/null; then
+    info "MuJoCo EGL rendering: OK"
+else
+    warn "MuJoCo EGL rendering failed. Trying osmesa..."
+    if MUJOCO_GL=osmesa "${PYTHON}" -c "import mujoco; print('MuJoCo OK')" 2>/dev/null; then
+        info "MuJoCo osmesa rendering: OK (use MUJOCO_GL=osmesa)"
+    else
+        warn "MuJoCo rendering not available. Install libosmesa6-dev or EGL libraries."
+    fi
+fi
+
+# ─── Verify PyTorch CUDA ────────────────────────────────────────────────────
+if [ "${SKIP_TORCH}" != "1" ]; then
+    info "Verifying PyTorch CUDA..."
+    CUDA_AVAIL=$("${PYTHON}" -c 'import torch; print(torch.cuda.is_available())' 2>/dev/null || echo "False")
+    if [ "${CUDA_AVAIL}" = "True" ]; then
+        GPU_COUNT=$("${PYTHON}" -c 'import torch; print(torch.cuda.device_count())')
+        info "PyTorch CUDA: OK (${GPU_COUNT} GPU(s))"
+    else
+        warn "PyTorch CUDA not available. Check CUDA toolkit version matches ${CUDA_VERSION}."
+    fi
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+info "Setup complete. Quick start:"
+echo "  # Run MuJoCo grasp demo"
+echo "  MUJOCO_GL=egl python examples/mujoco_grasp.py --report"
+echo ""
+echo "  # Run SONIC locomotion demo"
+echo "  python examples/sonic_locomotion.py --report"
+echo ""
+echo "  # Run tests"
+echo "  pytest"
+echo ""
+echo "  # Start Claude Code CLI"
+echo "  claude"


### PR DESCRIPTION
## Summary

- Add "Development environments" section to CLAUDE.md with web vs local CLI decision table and rule of thumb
- Add `scripts/gpu-dev-setup.sh` for reproducible local GPU environment setup (preflight checks, dependency install, GPU rendering verification)
- Add `Makefile` with targets for lint, format, typecheck, test, GPU verification (`check-gpu`), and running all demos (`demos`)

Closes #166

## Test plan

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `mypy src/` passes
- [x] `pytest` — 331 passed, 21 skipped
- [x] Makefile targets verified: `make lint`, `make test-quick`

https://claude.ai/code/session_015Dv6bPgNskTLBoRujs7Vb6