### PR TITLE
feat: #139 — add groot-n16 and sonic-locomotion showcases

### DIFF
--- a/scripts/init-showcase-repo.py
+++ b/scripts/init-showcase-repo.py
@@ -4,7 +4,9 @@
 Creates a complete, ready-to-push directory with:
   - Root README.md with overview and instructions
   - lerobot-g1/ showcase (adapted from examples/lerobot_g1_native.py)
-  - Placeholder directories for future showcases
+  - groot-n16/ showcase (adapted from examples/lerobot_g1.py)
+  - sonic-locomotion/ showcase (adapted from examples/sonic_locomotion.py)
+  - Placeholder directories for pi0-libero and capx-comparison
   - CI workflow (.github/workflows/showcase-ci.yml)
   - Org profile README (.github-org/profile/README.md)
 
@@ -12,7 +14,7 @@ Usage:
     python scripts/init-showcase-repo.py [OUTPUT_DIR]
 
 The default output directory is ``./showcase-output``. Run from the
-roboharness repo root so the script can find ``examples/lerobot_g1_native.py``.
+roboharness repo root so the script can find source examples.
 
 See: https://github.com/MiaoDX/roboharness/issues/139
 """
@@ -31,6 +33,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LEROBOT_EXAMPLE = REPO_ROOT / "examples" / "lerobot_g1_native.py"
+GROOT_EXAMPLE = REPO_ROOT / "examples" / "lerobot_g1.py"
+SONIC_EXAMPLE = REPO_ROOT / "examples" / "sonic_locomotion.py"
 
 SHOWCASE_DIRS = [
     "groot-n16",
@@ -45,11 +49,19 @@ SHOWCASE_DIRS = [
 # ---------------------------------------------------------------------------
 
 
+SHOWCASE_INFO: dict[str, tuple[str, str]] = {
+    "groot-n16": ("GR00T N1.6 WBC locomotion on Unitree G1", "Ready"),
+    "pi0-libero": ("Pi0 policy on LIBERO manipulation benchmark", "Planned"),
+    "lerobot-g1": ("LeRobot G1 native locomotion demo", "Ready"),
+    "sonic-locomotion": ("GEAR-SONIC planner locomotion on Unitree G1", "Ready"),
+    "capx-comparison": ("CaP-X benchmark comparison with roboharness", "Planned"),
+}
+
+
 def _root_readme() -> str:
     rows = []
     for d in SHOWCASE_DIRS:
-        desc = "LeRobot G1 native locomotion demo" if d == "lerobot-g1" else "Coming soon"
-        status = "Ready" if d == "lerobot-g1" else "Planned"
+        desc, status = SHOWCASE_INFO[d]
         rows.append(f"| [{d}]({d}/) | {desc} | {status} |")
     showcase_table = "\n".join(rows)
     return textwrap.dedent(f"""\
@@ -115,11 +127,10 @@ def _ci_workflow() -> str:
                 include:
                   - name: lerobot-g1
                     dir: lerobot-g1
-                    # Future showcases:
-                    # - name: groot-n16
-                    #   dir: groot-n16
-                    # - name: sonic-locomotion
-                    #   dir: sonic-locomotion
+                  - name: groot-n16
+                    dir: groot-n16
+                  - name: sonic-locomotion
+                    dir: sonic-locomotion
 
             name: ${{ matrix.name }}
             runs-on: ubuntu-latest
@@ -236,6 +247,241 @@ def _lerobot_run_sh() -> str:
     """)
 
 
+def _groot_readme() -> str:
+    return textwrap.dedent("""\
+        # GR00T N1.6 WBC Locomotion
+
+        Demonstrates [roboharness](https://github.com/MiaoDX/roboharness) integration with
+        the GR00T whole-body control (WBC) locomotion controller on the Unitree G1 humanoid.
+
+        Downloads the real 29-DOF G1 model from HuggingFace and runs it with the GR00T RL
+        balance/walk controller (ONNX), capturing multi-camera checkpoint screenshots via
+        `RobotHarnessWrapper`.
+
+        ## Requirements
+
+        - Python 3.10+
+        - MuJoCo with OSMesa for headless rendering (CI), or a display (local)
+
+        ## Quick start
+
+        ```bash
+        pip install -r requirements.txt
+        bash run.sh
+        ```
+
+        ## Run options
+
+        ```bash
+        # Default: GR00T controller with HTML report
+        MUJOCO_GL=osmesa python lerobot_g1.py --report
+
+        # With validation assertions (for CI)
+        MUJOCO_GL=osmesa python lerobot_g1.py --report --assert-success
+        ```
+
+        ## Output
+
+        ```
+        harness_output/lerobot_g1/trial_001/
+            initial/   -- robot in default standing pose
+            steady/    -- robot walking forward
+            terminal/  -- robot stopped, balancing
+        ```
+
+        Each checkpoint directory contains multi-camera PNG screenshots and a `state.json`
+        with joint angles, step count, and reward.
+
+        ## What this demonstrates
+
+        - **GR00T WBC controller**: ONNX-based balance + walk policies from NVIDIA
+        - **Multi-camera capture**: screenshots from all MuJoCo cameras at each checkpoint
+        - **Locomotion protocol**: structured phases (initial/steady/terminal)
+        - **Validation checks**: robot-stayed-upright assertions for CI
+
+        ## References
+
+        - [roboharness](https://github.com/MiaoDX/roboharness)
+        - [lerobot/unitree-g1-mujoco](https://huggingface.co/lerobot/unitree-g1-mujoco)
+        - [GR00T WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)
+    """)
+
+
+def _groot_requirements() -> str:
+    return textwrap.dedent("""\
+        roboharness[demo]
+        huggingface_hub
+    """)
+
+
+def _groot_run_sh() -> str:
+    return textwrap.dedent("""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Default to headless rendering if no display is available
+        export MUJOCO_GL="${MUJOCO_GL:-osmesa}"
+
+        echo "=== GR00T N1.6 WBC Locomotion Showcase ==="
+        echo "Controller: groot"
+        echo "MUJOCO_GL=$MUJOCO_GL"
+        echo ""
+
+        python lerobot_g1.py --report --assert-success
+    """)
+
+
+def _sonic_readme() -> str:
+    return textwrap.dedent("""\
+        # SONIC Locomotion
+
+        Demonstrates [roboharness](https://github.com/MiaoDX/roboharness) integration with
+        NVIDIA's GEAR-SONIC locomotion controller in planner mode on the Unitree G1 humanoid.
+
+        The SONIC controller uses ONNX models (downloaded from `nvidia/GEAR-SONIC` on
+        HuggingFace) to generate full-body pose trajectories from velocity commands.
+
+        ## Requirements
+
+        - Python 3.10+
+        - MuJoCo with OSMesa for headless rendering (CI), or a display (local)
+
+        ## Quick start
+
+        ```bash
+        pip install -r requirements.txt
+        bash run.sh
+        ```
+
+        ## Run options
+
+        ```bash
+        # Default: SONIC planner with HTML report
+        MUJOCO_GL=osmesa python sonic_locomotion.py --report
+
+        # Custom render resolution
+        MUJOCO_GL=osmesa python sonic_locomotion.py --report --width 1280 --height 960
+        ```
+
+        ## Output
+
+        ```
+        harness_output/sonic_locomotion/trial_001/
+            initial/   -- robot in default standing pose
+            walking/   -- walking forward via SONIC planner
+            stopping/  -- decelerating to stop
+            terminal/  -- stopped, balancing
+        ```
+
+        Each checkpoint directory contains multi-camera PNG screenshots and a `state.json`
+        with joint angles, step count, and reward.
+
+        ## What this demonstrates
+
+        - **SONIC planner mode**: velocity commands to full-body pose trajectories
+        - **ONNX inference**: models downloaded from HuggingFace on first use
+        - **Four-phase protocol**: stand, walk, decelerate, stop
+        - **Multi-camera capture**: screenshots from all MuJoCo cameras at each checkpoint
+
+        ## References
+
+        - [roboharness](https://github.com/MiaoDX/roboharness)
+        - [nvidia/GEAR-SONIC](https://huggingface.co/nvidia/GEAR-SONIC)
+        - [NVlabs/GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)
+    """)
+
+
+def _sonic_requirements() -> str:
+    return textwrap.dedent("""\
+        roboharness[demo]
+        huggingface_hub
+    """)
+
+
+def _sonic_run_sh() -> str:
+    return textwrap.dedent("""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # Default to headless rendering if no display is available
+        export MUJOCO_GL="${MUJOCO_GL:-osmesa}"
+
+        echo "=== SONIC Locomotion Showcase ==="
+        echo "Controller: GEAR-SONIC planner"
+        echo "MUJOCO_GL=$MUJOCO_GL"
+        echo ""
+
+        python sonic_locomotion.py --report
+    """)
+
+
+def _pi0_libero_readme() -> str:
+    return textwrap.dedent("""\
+        # Pi0 on LIBERO
+
+        *Planned.* This showcase will demonstrate roboharness integration with the
+        [Pi0](https://www.physicalintelligence.company/blog/pi0) generalist robot
+        policy on the [LIBERO](https://github.com/Lifelong-Robot-Learning/LIBERO)
+        manipulation benchmark.
+
+        ## Planned scope
+
+        - Run Pi0 policy on LIBERO-Spatial or LIBERO-Object tasks in MuJoCo
+        - Capture checkpoint screenshots at key manipulation stages
+        - Generate HTML reports comparing task success across episodes
+
+        ## Dependencies
+
+        - Pi0 model weights (requires access)
+        - LIBERO benchmark environments
+        - roboharness `RobotHarnessWrapper`
+
+        ## Contributing
+
+        Want to help build this showcase? Open an issue at
+        [roboharness/showcase](https://github.com/roboharness/showcase/issues).
+
+        ## References
+
+        - [roboharness](https://github.com/MiaoDX/roboharness)
+        - [Pi0 blog post](https://www.physicalintelligence.company/blog/pi0)
+        - [LIBERO benchmark](https://github.com/Lifelong-Robot-Learning/LIBERO)
+    """)
+
+
+def _capx_comparison_readme() -> str:
+    return textwrap.dedent("""\
+        # CaP-X Benchmark Comparison
+
+        *Planned.* This showcase will compare roboharness visual testing against the
+        [CaP-X](https://arxiv.org/abs/2603.22435) benchmark for coding agents that
+        program robot manipulation tasks.
+
+        ## Planned scope
+
+        - Run the same manipulation tasks from CaP-X using roboharness
+        - Compare evaluation approaches: CaP-X metrics vs roboharness checkpoints
+        - Demonstrate how visual checkpoint feedback improves agent iteration
+
+        ## Dependencies
+
+        - CaP-X benchmark environments
+        - MuJoCo or Isaac Lab backend
+        - roboharness `RobotHarnessWrapper`
+
+        ## Contributing
+
+        Want to help build this showcase? Open an issue at
+        [roboharness/showcase](https://github.com/roboharness/showcase/issues).
+
+        ## References
+
+        - [roboharness](https://github.com/MiaoDX/roboharness)
+        - [CaP-X paper](https://arxiv.org/abs/2603.22435)
+        - [CaP-X — Benchmark for Coding Agents](https://github.com/Autonomous-Robotics-Lab/CaP-X)
+    """)
+
+
 def _placeholder_readme(name: str) -> str:
     return textwrap.dedent(f"""\
         # {name}
@@ -305,11 +551,16 @@ def main() -> None:
     if output.exists() and args.force:
         shutil.rmtree(output)
 
-    # Check that the source example exists
-    if not LEROBOT_EXAMPLE.exists():
-        print(f"Error: cannot find {LEROBOT_EXAMPLE}")
-        print("Run this script from the roboharness repo root.")
-        sys.exit(1)
+    # Check that the source examples exist
+    for name, path in [
+        ("lerobot_g1_native", LEROBOT_EXAMPLE),
+        ("lerobot_g1", GROOT_EXAMPLE),
+        ("sonic_locomotion", SONIC_EXAMPLE),
+    ]:
+        if not path.exists():
+            print(f"Error: cannot find {path} ({name})")
+            print("Run this script from the roboharness repo root.")
+            sys.exit(1)
 
     print(f"Generating showcase repo in: {output}")
 
@@ -326,7 +577,7 @@ def main() -> None:
     # Org profile README (for roboharness/.github repo)
     (output / ".github-org" / "profile" / "README.md").write_text(_org_profile_readme())
 
-    # lerobot-g1 showcase (the first real showcase)
+    # lerobot-g1 showcase
     lerobot_dir = output / "lerobot-g1"
     shutil.copy2(LEROBOT_EXAMPLE, lerobot_dir / "lerobot_g1_native.py")
     (lerobot_dir / "README.md").write_text(_lerobot_readme())
@@ -335,11 +586,27 @@ def main() -> None:
     run_sh.write_text(_lerobot_run_sh())
     run_sh.chmod(0o755)
 
-    # Placeholder showcases
-    for d in SHOWCASE_DIRS:
-        if d == "lerobot-g1":
-            continue
-        (output / d / "README.md").write_text(_placeholder_readme(d))
+    # groot-n16 showcase
+    groot_dir = output / "groot-n16"
+    shutil.copy2(GROOT_EXAMPLE, groot_dir / "lerobot_g1.py")
+    (groot_dir / "README.md").write_text(_groot_readme())
+    (groot_dir / "requirements.txt").write_text(_groot_requirements())
+    run_sh = groot_dir / "run.sh"
+    run_sh.write_text(_groot_run_sh())
+    run_sh.chmod(0o755)
+
+    # sonic-locomotion showcase
+    sonic_dir = output / "sonic-locomotion"
+    shutil.copy2(SONIC_EXAMPLE, sonic_dir / "sonic_locomotion.py")
+    (sonic_dir / "README.md").write_text(_sonic_readme())
+    (sonic_dir / "requirements.txt").write_text(_sonic_requirements())
+    run_sh = sonic_dir / "run.sh"
+    run_sh.write_text(_sonic_run_sh())
+    run_sh.chmod(0o755)
+
+    # Detailed placeholder showcases
+    (output / "pi0-libero" / "README.md").write_text(_pi0_libero_readme())
+    (output / "capx-comparison" / "README.md").write_text(_capx_comparison_readme())
 
     # Summary
     print("\nGenerated structure:")


### PR DESCRIPTION
## Summary

- Adds **groot-n16** showcase (GR00T N1.6 WBC locomotion, adapted from `examples/lerobot_g1.py`) with README, requirements.txt, run.sh
- Adds **sonic-locomotion** showcase (GEAR-SONIC planner, adapted from `examples/sonic_locomotion.py`) with README, requirements.txt, run.sh
- Replaces generic placeholder READMEs for **pi0-libero** and **capx-comparison** with detailed, context-rich READMEs including planned scope, dependencies, and references
- Updates CI workflow matrix to include all three ready showcases (lerobot-g1, groot-n16, sonic-locomotion)
- Updates root README showcase table with proper descriptions and statuses

Continues the work from PR #175 on issue #139.

### Remaining work for #139 (requires manual action)

- [ ] Create `roboharness/showcase` repo on GitHub
- [ ] Run `python scripts/init-showcase-repo.py ./showcase-output` and push to the new repo
- [ ] Create `roboharness/.github` repo with org profile README
- [ ] Implement pi0-libero and capx-comparison showcases when dependencies are available

## Test plan

- [x] Script runs successfully: `python scripts/init-showcase-repo.py /tmp/test --force` generates all expected files
- [x] `ruff check` and `ruff format --check` pass
- [x] `mypy scripts/init-showcase-repo.py` passes
- [x] All 431 tests pass (8 skipped for optional deps)

https://claude.ai/code/session_01W7StCMGXwrH3RuVT68fV5a