### PR TITLE
chore: dependency & config hygiene 2026-04-11

### DIFF
--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install huggingface_hub
-        run: pip install huggingface_hub
+        run: pip install "huggingface_hub>=0.20"
 
       - name: Add Space metadata
         run: cp hf-space/README.md _site/README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,17 @@ jobs:
           echo "pyproject.toml version:"
           grep '^version' pyproject.toml
 
+      - name: Update __init__.py version to match pyproject.toml
+        run: |
+          sed -i "s/^__version__ = \".*\"/__version__ = \"${{ steps.version.outputs.new_version }}\"/" src/roboharness/__init__.py
+          echo "__init__.py version:"
+          grep '^__version__' src/roboharness/__init__.py
+
       - name: Commit version bump if needed
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
+          git add pyproject.toml src/roboharness/__init__.py
           if git diff --cached --quiet; then
             echo "No version change needed"
           else

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ demo = [
     "gymnasium>=0.29",
     "huggingface_hub>=0.20",
     "onnxruntime>=1.16",
-    "Pillow",
-    "robot_descriptions",
+    "Pillow>=9.0",
+    "robot_descriptions>=1.0",
     "rerun-sdk>=0.18",
 ]
 wbc = [
@@ -63,7 +63,7 @@ dev = [
     "mypy>=1.0",
     "pre-commit>=3.0",
     "gymnasium>=0.29",
-    "Pillow",
+    "Pillow>=9.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Saturday dependency & config hygiene cleanup

### Changes

- **`pyproject.toml`** — add `>=9.0` floor to `Pillow` in both `demo` and `dev` extras; add `>=1.0` floor to `robot_descriptions` in `demo`. Pillow 9.0 (Jan 2022) is a safe minimum for a Python 3.10+ project. Previously these were fully unpinned, allowing arbitrarily old versions.

- **`.github/workflows/release.yml`** — fix version sync bug: the release workflow updated `pyproject.toml` via `sed` but never touched `src/roboharness/__init__.py`. CLAUDE.md explicitly requires both files to stay in sync. Now both are updated in the same sed+commit step.

- **`.github/workflows/hf-space.yml`** — pin `huggingface_hub>=0.20` to match the floor already declared in the `demo` extra. The bare `pip install huggingface_hub` could silently pull an older incompatible version.

### Verification

- `ruff check . && ruff format --check .` — all clean
- `pytest --no-cov` — 431 passed, 8 skipped