### PR TITLE
fix: #156 — Robotics Factory Accelerate evaluation (not a fit)

### DIFF
--- a/docs/funding/robotics-factory-evaluation.md
+++ b/docs/funding/robotics-factory-evaluation.md
@@ -1,0 +1,60 @@
+# Robotics Factory Accelerate — Fit Evaluation
+
+_Evaluated: April 2026_
+_Program deadline: July 18, 2026_
+_Program URL: https://www.roboticsfactory.org/accelerate_
+
+---
+
+## Program Summary
+
+The Robotics Factory Accelerate program is a **12-month startup accelerator** for early-stage
+robotics companies in the Pittsburgh, PA area (SWPA). Up to 6 companies per cohort receive:
+
+- Up to $100,000 in funding
+- Office space at the Lawrenceville facility
+- Prototyping workshop and robotics testing equipment
+- Mentorship via Pittsburgh Robotics Network
+- Business coaching and manufacturing bootcamp
+
+**Eligibility requirements:**
+- Must be a pre-seed startup with a robotics product (sense, perceive, act)
+- Must have completed customer discovery and be engaging with potential customers
+- Must maintain significant physical presence in SWPA during the 12-month program and for
+  5 years afterward
+
+## Fit Assessment: **Not a fit — recommend skip**
+
+| Criterion | Required | roboharness | Fit? |
+|---|---|---|---|
+| Entity type | Startup/company | Open-source project | ✗ |
+| Product type | Robotics hardware/software (sense, perceive, act) | Testing harness / dev tool | ✗ |
+| Geographic requirement | Physical presence in SWPA (Pittsburgh, PA) | No fixed location | ✗ |
+| Customer discovery | Completed, actively engaging customers | No commercial customers | ✗ |
+| Revenue stage | Pre-revenue acceptable | Pre-revenue | ✓ |
+
+### Conclusion
+
+roboharness does not qualify on three fundamental criteria:
+
+1. **Not a company.** The program is explicitly for startups. roboharness is an open-source
+   project maintained by an individual contributor, not incorporated as a business.
+
+2. **Product mismatch.** The program targets robots that "sense, perceive, act" — physical or
+   embodied robotics products. roboharness is developer tooling (a testing harness), which
+   sits one layer above the hardware/firmware the program is designed for.
+
+3. **Geographic constraint.** The program requires 5+ years of physical presence in
+   Southwest Pennsylvania. This is a hard disqualifier regardless of other criteria.
+
+## Recommendation
+
+**Do not apply.** No amount of positioning or framing changes the fundamental eligibility gap.
+Applying would waste evaluator time and reflect poorly on the project.
+
+**Better funding targets (already in progress):**
+- Anthropic Claude for Open Source — deadline June 30, 2026
+  (see `docs/funding/anthropic-oss-application.md`)
+- Google DeepMind Accelerator: Robotics — monitor for future cohort announcements
+- GSoC 2027 org application — prepare Q4 2026
+- NumFOCUS affiliated project — evaluate end of Q2 2026


### PR DESCRIPTION
## Summary

- Fetched and evaluated the Robotics Factory Accelerate program requirements
- Determined roboharness is **not a fit** on three hard disqualifiers:
  1. Program requires an incorporated startup — roboharness is an open-source project
  2. Product mismatch — program targets embodied robotics (sense/perceive/act hardware); roboharness is developer tooling
  3. 5-year physical presence in Pittsburgh PA required — no geographic anchor exists

## Changes

- Adds `docs/funding/robotics-factory-evaluation.md` with fit assessment table, conclusion, and redirect to better-matched funding paths (Anthropic OSS, Google DeepMind Accelerator)

## Resolves

Closes #156

https://claude.ai/code/session_01HTT93Dcc4vG5bAUEikFYRc