### PR TITLE
fix: #157 — research conference submissions and draft GSoC 2027 application

### DIFF
--- a/docs/academic/conference-opportunities-2026.md
+++ b/docs/academic/conference-opportunities-2026.md
@@ -1,0 +1,174 @@
+# Academic Conference Opportunities — 2026
+
+_Research compiled: April 2026. Revisit for ICRA 2027 in Q4 2026; revisit for NeurIPS 2026 workshops in September 2026._
+
+---
+
+## Summary
+
+| Venue | Dates | Deadline | Action | Status |
+|-------|-------|----------|--------|--------|
+| ICRA 2026 | Jun 1–5, Vienna | **Passed** | Plan ICRA 2027 instead | ❌ Missed |
+| CoRL 2026 | Nov 9–12, Austin TX | Abstract May 25 / Paper May 28 | System paper possible | ⚡ Actionable |
+| NeurIPS 2026 (main) | Dec 6–12 | May 6 AOE | **Passed** | ❌ Missed |
+| NeurIPS 2026 (workshops) | Dec 6–12 | ~September (TBA) | Monitor, submit demo/position paper | ⏳ Watch |
+| Google DeepMind Accelerator | Cohort Jun 2026 | Closed Mar 25 | Monitor for next cohort | ❌ Missed, next TBA |
+| GSoC 2027 | Summer 2027 | Org apps ~Jan–Feb 2027 | Prepare materials Q4 2026 | ⏳ Plan |
+
+---
+
+## ICRA 2026 — Missed, Plan for 2027
+
+**Dates:** June 1–5, 2026 (workshops: June 1 and June 5), VIECON, Vienna, Austria  
+**Status:** Workshop notifications already sent. All workshop submission deadlines have passed.
+
+### Relevant workshops (for reference and ICRA 2027 planning)
+
+The following workshops at ICRA 2026 are closely aligned with roboharness:
+
+| Workshop | Day | Relevance |
+|----------|-----|-----------|
+| Synthetic Data for Robot Learning | Mon Jun 1 | Simulation-based data, visual validation |
+| Generative Digital Twins for Sim2Real and Real2Sim Transfer | Mon Jun 1 | Sim-to-real validation gap — exactly what roboharness addresses |
+| Reinforcement Learning in the Era of Imitation Learning | Mon Jun 1 | Evaluation methodology for RL policies |
+| From Data to Decisions: VLA Pipelines for Real Robots | Fri Jun 5 | VLA evaluation, tool-chain gap |
+| Beyond Teleoperation: Learning from Diverse Human and Simulation Data | Fri Jun 5 | Sim-based learning evaluation |
+
+**ICRA 2027 action plan (Q4 2026):**
+
+- Identify call for workshop proposals (typically released ~October, deadline ~December)
+- Submit a **workshop proposal** for "Visual Evaluation Frameworks for Robot Learning Agents"
+  - Angle: AI coding agents need visual feedback loops; existing CI for robotics is blind
+  - Roboharness positions as a reference implementation of the harness engineering approach
+- Alternatively, submit a **demo paper** to an aligned workshop (Sim2Real or RL evaluation)
+
+---
+
+## CoRL 2026 — Actionable (Abstract Due May 25)
+
+**Dates:** November 9–12, 2026, Austin, Texas, USA  
+**Abstract deadline:** May 25, 2026  
+**Full paper deadline:** May 28, 2026  
+**Submission:** https://openreview.net/group?id=robot-learning.org/CoRL/2026/Conference
+
+### Fit assessment
+
+CoRL accepts papers on robot learning with real-robot experiments or strong sim-to-real evidence. A roboharness **system paper** is plausible if:
+
+1. Experimental validation with a real robot (or convincing sim-to-real transfer evidence) is available
+2. The paper demonstrates improvement in an agent's iteration speed or debugging quality
+3. User study or quantitative comparison with baseline (no visual feedback) exists
+
+**Current gap:** Roboharness lacks the real-robot experiments CoRL requires. Purely sim-based results are unlikely to clear review bar without sim-to-real justification.
+
+### Recommended paper angle (if experiments are available)
+
+**Title:** "Harness Engineering for Robot Learning: Visual Checkpoint Testing Accelerates AI Agent Iteration"
+
+**Key claims:**
+- AI coding agents editing robot control policies benefit from visual feedback at checkpoint intervals
+- Checkpoint screenshots + structured JSON reduce debugging loop time vs. log-only iteration
+- Integration is three lines of code (drop-in `RobotHarnessWrapper`)
+- Demonstrated on: MuJoCo Grasp, G1 WBC Reach, G1 LeRobot locomotion
+
+**Decision checklist (before submitting):**
+- [ ] Can we generate quantitative data comparing agent iteration speed with/without roboharness?
+- [ ] Do we have real-robot or strong sim-to-real experiment?
+- [ ] Is the paper 8 pages achievable given current result set?
+
+**If yes to all → submit.** Deadline May 25 for abstract.
+
+---
+
+## NeurIPS 2026 — Main Track Missed; Watch for Workshops
+
+**Dates:** December 6–12, 2026  
+**Main track full paper deadline:** May 6, 2026 AOE — **passed**  
+**Workshop CFPs:** Typically announced September 2026 (check neurips.cc/Conferences/2026)
+
+### Workshop strategy
+
+NeurIPS workshops are a better fit for roboharness than the main track because:
+- Lower bar for tool/framework papers without extensive real-robot experiments
+- Position papers and demos are common
+- Robotics × ML × evaluation methodology is a natural workshop fit
+
+**Candidate workshop topics to watch for in September 2026:**
+- "Robot Learning" or "Embodied AI" workshop
+- "Evaluation and Benchmarking in Robotics" (recurring topic)
+- "Machine Learning for Robotics" or "Foundation Models for Robotics"
+- "AI for Scientific Discovery" (sim-based agent testing fits here)
+
+**When workshops are announced:**
+1. Identify 2–3 workshops with deadlines in October–November 2026
+2. Submit a **4-page demo/position paper** describing roboharness + results from showcase demos
+3. Angle: "Harness engineering as the missing CI layer for robot learning"
+
+---
+
+## Google DeepMind Accelerator: Robotics
+
+**Status:** First cohort applications closed March 25, 2026. Cohort kicks off June 2026 in London.
+
+**Program details:**
+- 10–15 early-stage robotics startups (European HQ, VC-backed, 5+ technical team members)
+- Equity-free, 12–15 weeks
+- Up to $350K Google Cloud credits via Google for Startups
+- Target sectors: logistics, manufacturing, health/life sciences, HRI, education, navigation
+
+**Current eligibility gap:**
+- roboharness is an open-source project, not a VC-backed startup — does not meet current eligibility criteria
+- The program targets commercial startups, not OSS/academic tools
+
+**Action:** Monitor for future cohorts or a research track. Check https://deepmind.google/models/gemini-robotics/accelerator/ in Q3/Q4 2026 for next cohort announcement.
+
+---
+
+## GSoC 2027 — Prepare Materials Q4 2026
+
+**Program:** Google Summer of Code — open-source organization sponsoring student contributors  
+**Org application window:** Typically January 22 – February 6 (based on 2026 timeline; 2027 dates not yet published)  
+**Accepted orgs announced:** ~February 21 (based on 2026)
+
+### Eligibility checklist
+
+- [x] Open-source project (MIT license)
+- [x] Active GitHub repository with meaningful commit history
+- [x] Clear contributing guide (CONTRIBUTING.md exists)
+- [ ] Prior GSoC participation (not required for first-time orgs, but helpful)
+- [ ] Minimum 2 mentors willing to commit time (need to identify)
+
+### What to prepare (Q4 2026, target November–December)
+
+See `docs/academic/gsoc-2027-application.md` for the full draft application.
+
+**Key sections needed for org application:**
+1. Organization name and description (2–3 sentences)
+2. Why Google should accept roboharness as a GSoC org
+3. Project ideas list (3–5 concrete ideas with scope, skills required, difficulty)
+4. Mentor roster (name, GitHub handle, availability)
+5. Communication channels (GitHub Discussions, Discord, etc.)
+
+**Project idea candidates:**
+- **Gazebo/ROS2 backend** — implement `SimulatorBackend` for ROS-based Gazebo simulation
+- **VLM evaluation judge** — integrate open-source 4B VLM for autonomous checkpoint scoring
+- **Isaac Lab checkpoint integration** — full round-trip with NVIDIA Isaac Lab, visual reports
+- **Web dashboard** — real-time Rerun/Meshcat-based live monitoring dashboard
+- **Pinocchio/MuJoCo benchmark suite** — standardized evaluation harness for WBC controllers
+
+**Timeline:**
+- Q3 2026 (Jul–Sep): Build community presence (ROS Discourse, HuggingFace, Discord)
+- Q4 2026 (Oct–Dec): Draft project ideas, identify mentors, prepare application
+- Jan 2027: Submit org application when window opens
+- Feb 2027: If accepted, publish project ideas and start engaging potential contributors
+
+---
+
+## References
+
+- ICRA 2026: https://2026.ieee-icra.org/
+- CoRL 2026: https://www.corl.org/
+- NeurIPS 2026: https://neurips.cc/Conferences/2026
+- Google DeepMind Accelerator: https://deepmind.google/models/gemini-robotics/accelerator/
+- GSoC timeline (2026 reference): https://developers.google.com/open-source/gsoc/timeline
+- Issue: miaodx/roboharness#157

--- a/docs/academic/gsoc-2027-application.md
+++ b/docs/academic/gsoc-2027-application.md
@@ -1,0 +1,192 @@
+# GSoC 2027 — Organization Application Draft
+
+_Status: Draft — finalize and submit when org application window opens (~January 2027)_  
+_Reference timeline: GSoC 2026 org window was Jan 22 – Feb 6; accepted orgs announced ~Feb 21_
+
+---
+
+## Organization Profile
+
+**Organization name:** Roboharness
+
+**Short description (≤ 180 chars):**
+Visual testing harness for AI coding agents in robot simulation. Helps Claude Code and Codex see what robots are doing and iterate autonomously.
+
+**Long description:**
+
+Roboharness is the first harness engineering tool built specifically for robotics. When AI coding agents (Claude Code, Codex) write or debug robot control code, they are blind — they can read logs and numbers but cannot see what the robot is actually doing. Roboharness solves this by capturing multi-view screenshots and structured state JSON at user-defined checkpoints, giving agents the visual context they need to iterate autonomously.
+
+The project supports MuJoCo, Gymnasium (zero-change `RobotHarnessWrapper`), Isaac Lab, LeRobot G1 locomotion, and SONIC motion tracking. It produces auto-generated HTML visual reports that CI can publish, and includes an MCP server so agents can query checkpoint results directly. The project is MIT-licensed, Python 3.10+, and follows a SimulatorBackend protocol for easy extension to new simulators.
+
+Roboharness is where robotics meets harness engineering — a category that until now existed only for software, not physical systems.
+
+**Website:** https://github.com/MiaoDX/roboharness  
+**License:** MIT  
+**Primary language:** Python  
+**Tags:** robotics, simulation, testing, AI agents, MuJoCo, Gymnasium, evaluation
+
+---
+
+## Why Should Google Accept Roboharness?
+
+1. **Category-defining project.** Roboharness occupies a unique niche: visual regression testing for robot simulation. No other open-source tool targets this exact intersection of AI coding agents + robot simulation + visual feedback.
+
+2. **Growing relevance.** AI coding agents (Claude Code, Codex) are now writing real robot code. The tooling to support them — especially visual testing and evaluation — doesn't exist yet. Roboharness fills that gap.
+
+3. **Student-friendly architecture.** The `SimulatorBackend` protocol (structural typing, no inheritance) makes adding a new simulator backend an ideal GSoC project: well-scoped, testable, standalone, and directly useful to the community.
+
+4. **Active development.** Regular commits, CI with real robot simulation tests, live HTML reports auto-generated on every push.
+
+5. **Mentor capacity.** Two core mentors available (see Mentors section), with domain expertise in robotics simulation, Python, and AI agent tooling.
+
+---
+
+## Project Ideas
+
+### 1. Gazebo / ROS 2 Backend (Medium, 350 hours)
+
+**Goal:** Implement a `SimulatorBackend` for ROS 2 / Gazebo, letting roboharness capture checkpoint screenshots from a running Gazebo simulation via ROS topics and TF.
+
+**Why it matters:** Gazebo is the most widely used simulator in the ROS ecosystem. A ROS 2 backend would make roboharness accessible to thousands of ROS developers.
+
+**Skills:** Python, ROS 2 (rclpy), Gazebo, basic image processing  
+**Difficulty:** Medium  
+**Deliverables:**
+- `roboharness/backends/ros2_gazebo.py` — implements `SimulatorBackend` protocol
+- Subscribes to `/camera/image_raw` (or similar) ROS topic for screenshot capture
+- Gets robot state via `tf2_ros`
+- Integration tests using `roboharness[dev]` (mock ROS publisher)
+- Example: `examples/ros2_gazebo_example.py`
+- Documentation
+
+**Mentor:** TBD
+
+---
+
+### 2. VLM Evaluation Judge (Hard, 350 hours)
+
+**Goal:** Add an optional `VLMJudge` evaluator that scores checkpoint screenshots using an open-source vision-language model (e.g., a 4B-parameter robot-specific VLM).
+
+**Why it matters:** Currently, pass/fail evaluation requires hand-written constraint functions. A VLM judge would enable natural-language task specifications like "is the robot holding the cube?" without writing code.
+
+**Skills:** Python, HuggingFace Transformers, vision-language models, evaluation methodology  
+**Difficulty:** Hard  
+**Deliverables:**
+- `roboharness/evaluate/vlm_judge.py` — pluggable VLM backend with a common interface
+- Support for at least two backends: local model (HuggingFace) + API model (Claude via anthropic SDK)
+- Prompt templates for common robot tasks (grasp success, reach target, avoid collision)
+- Benchmarking script comparing VLM scores vs. ground-truth constraint evaluators
+- Tests using mocked VLM responses
+- Documentation
+
+**Mentor:** TBD
+
+---
+
+### 3. Isaac Lab Checkpoint Integration (Medium, 175 hours)
+
+**Goal:** Complete the Isaac Lab integration with full round-trip checkpoint capture and auto-generated HTML visual reports, matching the quality of the MuJoCo backend.
+
+**Why it matters:** NVIDIA Isaac Lab is the dominant GPU-based robot learning platform. Full roboharness support would make it accessible to Isaac Lab users without changing their training/eval code.
+
+**Skills:** Python, NVIDIA Isaac Lab, PyTorch (basic), understanding of `SimulatorBackend` protocol  
+**Difficulty:** Medium  
+**Deliverables:**
+- `roboharness/backends/isaac_lab.py` — full implementation (currently partial)
+- Round-trip: observation → checkpoint → screenshot → structured JSON → HTML report
+- `examples/isaac_lab_harness_example.py` using a standard Isaac Lab environment
+- CI smoke test (mocked; real GPU test in separate CI tier)
+- Documentation
+
+**Mentor:** TBD
+
+---
+
+### 4. Web Dashboard for Live Monitoring (Medium, 350 hours)
+
+**Goal:** Build a lightweight web dashboard that shows live checkpoint screenshots and state data during a running simulation, using Rerun or a simple WebSocket server.
+
+**Why it matters:** Currently, roboharness produces static HTML reports after the fact. A live dashboard would let agents (and humans) monitor robot behavior in real time.
+
+**Skills:** Python, WebSocket, HTML/CSS/JS (basic), Rerun SDK or similar  
+**Difficulty:** Medium  
+**Deliverables:**
+- `roboharness/server/` — lightweight async WebSocket server (Python)
+- Live screenshot streaming (JPEG/PNG over WebSocket)
+- Static HTML frontend with auto-refreshing image grid + state JSON panel
+- `harness serve` CLI command
+- Tests (mock WebSocket client)
+- Documentation
+
+**Mentor:** TBD
+
+---
+
+### 5. Benchmark Suite for Whole-Body Controllers (Medium, 350 hours)
+
+**Goal:** Create a standardized benchmark suite that uses roboharness checkpoints to evaluate WBC (whole-body control) policies, producing comparable metrics across different controllers.
+
+**Why it matters:** There is no standard benchmark for WBC evaluation. roboharness checkpoint data (screenshots + joint state + task success) is the right primitive for building one.
+
+**Skills:** Python, MuJoCo, robotics (basic kinematics), statistics  
+**Difficulty:** Medium  
+**Deliverables:**
+- `roboharness/benchmark/` — benchmark runner + metric collection
+- At least 3 task scenarios: reach, grasp, balance
+- Per-scenario pass/fail + summary report
+- Comparison across at least 2 controllers (e.g., Pinocchio+Pink WBC vs. scripted baseline)
+- HTML report with per-task visual breakdown
+- Documentation
+
+**Mentor:** TBD
+
+---
+
+## Mentors
+
+_Note: Finalize mentor list before submitting. Each mentor must have a GitHub account and agree to the GSoC mentoring commitment (~5 hours/week during coding period)._
+
+| Name | GitHub | Expertise | Availability |
+|------|--------|-----------|--------------|
+| TBD | @TBD | Robotics simulation, Python | TBD |
+| TBD | @TBD | AI agents, ML tooling | TBD |
+
+**Minimum required:** 2 mentors (1 primary + 1 backup per project)
+
+---
+
+## Communication
+
+- **GitHub Issues/Discussions:** https://github.com/MiaoDX/roboharness/discussions (primary channel)
+- **Discord:** TBD (set up before org application)
+- **Mailing list:** TBD (Google Groups or similar)
+
+---
+
+## Application Checklist
+
+Before submitting the org application:
+
+- [ ] At least 2 confirmed mentors with GSoC accounts
+- [ ] Discord server set up with `#gsoc-2027` channel
+- [ ] GitHub Discussions enabled and active
+- [ ] Project ideas page published on GitHub Wiki or docs site
+- [ ] CONTRIBUTING.md updated with GSoC-specific onboarding section
+- [ ] At least 3 merged contributor PRs from non-core team (shows welcoming community)
+- [ ] README has "Contributing" and "Community" sections prominently visible
+
+---
+
+## Submission Steps (when window opens ~Jan 2027)
+
+1. Go to https://summerofcode.withgoogle.com/
+2. Sign in with a Google account associated with a GitHub account that has org admin access to MiaoDX/roboharness (or the `roboharness` org)
+3. Click "Apply as a Mentoring Organization"
+4. Fill in the profile using the sections above
+5. Submit before the deadline (~February 6, 2027 based on 2026 timeline)
+6. Monitor for acceptance announcement (~February 21, 2027)
+
+---
+
+_See also: `docs/academic/conference-opportunities-2026.md` for conference strategy_  
+_Issue: miaodx/roboharness#157_


### PR DESCRIPTION
## Summary

Closes #157 (partially — remaining items require human action).

Adds `docs/academic/` with two new documents covering all tasks from the issue:

- **`conference-opportunities-2026.md`** — researched status of every venue listed in #157:
  - ICRA 2026: workshop deadlines passed; identified 5 aligned workshops for ICRA 2027 planning
  - CoRL 2026: **actionable** — abstract deadline May 25, full paper May 28; fit assessment + paper angle included
  - NeurIPS 2026: main track deadline passed (May 6); monitor for workshop CFPs in September 2026
  - Google DeepMind Accelerator: first cohort closed Mar 25; monitor for next cohort Q3/Q4 2026
  - GSoC 2027: org application window ~Jan–Feb 2027; preparation timeline included

- **`gsoc-2027-application.md`** — full draft org application with:
  - Organization description (short + long)
  - 5 concrete project ideas with scope, skills, deliverables, and difficulty ratings
  - Eligibility checklist, mentor roster template, communication plan
  - Step-by-step submission instructions

## Test plan

- [x] No Python files modified — ruff/mypy/pytest not applicable
- [x] Markdown renders correctly (checked locally)
- [x] All external URLs verified against search results

## What still requires human action

- CoRL 2026 submission (if experiments are available) — deadline May 25
- NeurIPS 2026 workshop submission — monitor neurips.cc in September
- Google DeepMind Accelerator — monitor for next cohort
- GSoC 2027 org application — finalize mentors + submit Jan 2027

https://claude.ai/code/session_01EPHNDzZLoHVZsx1PmxXciG