### PR TITLE
release: v0.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,25 @@ When reviewing a PR (as an agent or on behalf of one), **push fixes directly to 
 
 Do NOT create a new branch or a new PR for review fixes.
 
+### Release process
+
+Releases are cut by pushing to the `release` branch, which triggers `.github/workflows/release.yml` to tag, create a GitHub Release, and publish to PyPI via OIDC trusted publishing.
+
+**Important:** The `release` branch has **unrelated git history** (no common ancestor with `main`). It exists only as a deploy pointer. GitHub UI cannot merge unrelated histories, so **never open a PR targeting `release`**. Use this flow:
+
+1. Bump the version in **both** `pyproject.toml` and `src/roboharness/__init__.py` on a feature branch (e.g. `claude/release-<slug>`). Use semver — minor bump for feature milestones, patch for fix-only rollups.
+2. Open a PR targeting **`main`** (never `release`). Write release notes in the PR description summarizing what landed since the last tag.
+3. After CI is green and the PR is merged into `main`, force-push `release` to `main`'s tip:
+   ```bash
+   git fetch origin main
+   git push origin +origin/main:release   # or: git push --force origin main:release
+   ```
+   This is a force-push by design — `release` is a deploy pointer, not a history-preserving branch. Requires explicit user authorization each time.
+4. The push triggers the workflow: reads version from `pyproject.toml`, tags `vX.Y.Z`, generates release notes (`gh release create --generate-notes`), builds, publishes to PyPI.
+5. Verify the GitHub Release, the `vX.Y.Z` tag, and the PyPI artifact before closing out.
+
+If a duplicate PR targeting `release` was auto-created on push, close it — the `main`-targeted PR is the canonical one.
+
 ## CI failure investigation
 
 When a CI check fails, **always read the actual logs/error messages** before diagnosing. Do not stop at the status summary (`conclusion: failure`). Specifically:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "roboharness"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Visual Testing Harness for AI Coding Agents in Robot Simulation"
 readme = "README.md"
 license = "MIT"

--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -1,6 +1,6 @@
 """Roboharness: A Visual Testing Harness for AI Coding Agents in Robot Simulation."""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 from roboharness.core.capture import CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore


### PR DESCRIPTION
## Summary

Cut **v0.2.0** — a milestone release covering the substantial work landed since `v0.1.1`.

Version bumped in both sources of truth:
- `pyproject.toml`: `0.1.1` → `0.2.0`
- `src/roboharness/__init__.py`: `__version__` synced

## Why a minor bump

Since `v0.1.1` we've shipped feature-scale additions, not just patches:

- **MCP server** — batch evaluation tool, base64 screenshots, tests + SKILL.md (#70, #142)
- **LeRobot integration** — evaluation plugin for visual regression + `VectorEnvAdapter` for `make_env()` (#74)
- **HuggingFace Space** — deploy demo reports; workflow pinned (`huggingface_hub>=0.20`)
- **G1-native demo** — multi-policy controller via `--controller` param; groot-n16 / sonic-locomotion showcases (#139)
- **Showcase init script** — bootstrap showcase repos
- **Locomotion controllers & WBC grasp** re-integration (#67) with API friction fixes
- **Reports** — pass/fail visual indicators (#138), Pages deploy hardening
- **Docs** — Harness Engineering article (#153), Related Work, development workflow (web vs local GPU), GPU dev setup script, CITATION.cff
- **Infra** — dependency pinning (Pillow, robot_descriptions, huggingface_hub), mypy fixes, auto-label script, local validation stabilization

## Release flow

> **Note:** Retargeted from `release` → `main` because the `release` branch has unrelated git history (no common ancestor with `main`). GitHub UI cannot merge unrelated histories. The plan:
>
> 1. Merge this PR → `main` carries the `0.2.0` bump (transparent, auditable in main's history)
> 2. Force-push `release` → `main`'s tip
> 3. `.github/workflows/release.yml` triggers on push-to-release: tags `v0.2.0`, creates GitHub Release with auto-generated notes, publishes to PyPI via trusted publishing

The duplicate PR #193 (targeting `release`) has been closed.

## Test plan

- [x] Version bumped consistently in `pyproject.toml` and `__init__.py`
- [ ] CI green on this branch
- [ ] After merge to main: force-push `release` to main's tip
- [ ] Verify `v0.2.0` tag, GitHub Release, and PyPI artifact published

https://claude.ai/code/session_01WZn9JKchrtxVcPiy92ANgL