### PR TITLE
release: v0.2.1 (fix PyPI publish — drop git direct-ref)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,14 @@ jobs:
       - name: Install system dependencies (OSMesa for headless rendering)
         run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
 
-      - name: Install package with demo + unitree dependencies
-        run: uv pip install --system -e ".[demo,unitree]"
+      - name: Install package with demo dependencies
+        run: uv pip install --system -e ".[demo]"
+
+      - name: Install unitree SDK directly from fork
+        run: |
+          # unitree-sdk2py is installed directly (not via a pyproject extra —
+          # PyPI rejects packages with git-based direct references on upload)
+          uv pip install --system "unitree-sdk2py @ git+https://github.com/MiaoDX-fork-and-pruning/unitree_sdk2_python_uv.git"
 
       - name: Install CPU PyTorch and lerobot
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Install unitree SDK, CPU PyTorch, and lerobot
         run: |
-          uv pip install --system -e ".[unitree]"
+          # unitree-sdk2py is installed directly from the fork (not a pyproject
+          # extra — PyPI rejects packages with git-based direct references).
+          uv pip install --system "unitree-sdk2py @ git+https://github.com/MiaoDX-fork-and-pruning/unitree_sdk2_python_uv.git"
           uv pip install --system torch --index-url https://download.pytorch.org/whl/cpu
           uv pip install --system lerobot
           uv pip install --system loguru pygame scipy pyyaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,17 @@ Releases are cut by pushing to the `release` branch, which triggers `.github/wor
 
 If a duplicate PR targeting `release` was auto-created on push, close it — the `main`-targeted PR is the canonical one.
 
+**Environment protection:** The PyPI publish step uses the `pypi` GitHub environment. Its **Deployment branches and tags** rule must allow the `release` branch (and `v*` tag pattern if we ever switch to tag-triggered deploys). If this rule is missing, the workflow fails with `Branch 'release' is not allowed to deploy to pypi due to environment protection rules` in 1–2 seconds. Fix in Settings → Environments → pypi, then re-run the failed job.
+
+**No git-based direct references in `pyproject.toml`:** PyPI rejects uploads that declare dependencies like `pkg @ git+https://...`, even inside optional extras, with `400 Can't have direct dependency`. The `allow-direct-references = true` hatch setting only silences the *build-time* check — PyPI still refuses on upload. Any fork/git dep must be installed via a separate step (Dockerfile, CI workflow, docs) rather than through `[project.optional-dependencies]`. See the `unitree-sdk2py` handling in `Dockerfile` and `.github/workflows/pages.yml` for the pattern.
+
+**Validating a release end-to-end:** A successful GitHub Release + tag does **not** imply PyPI publication. The workflow creates the tag and release *before* building and uploading the wheel, so a PyPI failure still leaves a tag behind. Always confirm all three:
+1. `vX.Y.Z` tag at https://github.com/MiaoDX/roboharness/tags
+2. GitHub Release at https://github.com/MiaoDX/roboharness/releases/tag/vX.Y.Z
+3. PyPI artifact at https://pypi.org/project/roboharness/X.Y.Z/ (or via `curl -s https://pypi.org/pypi/roboharness/json | jq -r .info.version`)
+
+If PyPI publish fails mid-flow, do **not** reuse the broken version number — bump to the next patch (e.g. `0.2.0` broken → release as `0.2.1`). The broken version's tag and GitHub Release can stay as historical markers.
+
 ## CI failure investigation
 
 When a CI check fails, **always read the actual logs/error messages** before diagnosing. Do not stop at the status summary (`conclusion: failure`). Specifically:

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,9 @@ RUN mkdir -p src/roboharness && \
 # Install all dependency groups
 RUN uv pip install -e ".[demo,dev]"
 
-# Install unitree SDK (from fork, for native LeRobot G1 env)
-RUN uv pip install -e ".[unitree]"
+# Install unitree SDK directly from fork (not declared as a pyproject extra
+# because PyPI rejects packages with git-based direct references on upload)
+RUN uv pip install "unitree-sdk2py @ git+https://github.com/MiaoDX-fork-and-pruning/unitree_sdk2_python_uv.git"
 
 # Install CPU-only PyTorch + lerobot (for native LeRobot examples)
 RUN uv pip install torch --index-url https://download.pytorch.org/whl/cpu && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "roboharness"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Visual Testing Harness for AI Coding Agents in Robot Simulation"
 readme = "README.md"
 license = "MIT"
@@ -52,9 +52,6 @@ lerobot = [
     "gymnasium>=0.29",
     "mujoco>=3.0",
     "Pillow",
-]
-unitree = [
-    "unitree-sdk2py @ git+https://github.com/MiaoDX-fork-and-pruning/unitree_sdk2_python_uv.git",
 ]
 dev = [
     "pytest>=7.0",

--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -1,6 +1,6 @@
 """Roboharness: A Visual Testing Harness for AI Coding Agents in Robot Simulation."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 from roboharness.core.capture import CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore


### PR DESCRIPTION
## Summary

`v0.2.0` reached GitHub (tag + Release) but **PyPI rejected the upload** with:

```
400 Can't have direct dependency: unitree-sdk2py @ git+https://github.com/MiaoDX-fork-and-pruning/unitree_sdk2_python_uv.git ; extra == "unitree"
```

PyPI forbids packages that declare git-based direct references anywhere in `pyproject.toml`, including optional extras. Hatch's `allow-direct-references = true` only silences the local build check — upload still fails.

Releasing as **`0.2.1`** (per discussion: leave broken `v0.2.0` tag + GitHub Release as historical markers, no rollback needed since nothing was ever published to PyPI under that number).

## Changes

- `pyproject.toml`: remove the `[unitree]` optional extra entirely; bump version to `0.2.1`
- `src/roboharness/__init__.py`: sync `__version__`
- `Dockerfile`: install `unitree-sdk2py` directly from the fork via `pip install "pkg @ git+..."` (was `pip install -e ".[unitree]"`)
- `.github/workflows/pages.yml`: same direct install for Pages build
- `CLAUDE.md`: codify the lessons in the Release process section:
  - PyPI environment protection rule must allow the `release` branch
  - **No git direct refs in `pyproject.toml`** (even in optional extras) — PyPI rejects on upload
  - **Verify all three** after every release: tag, GitHub Release, PyPI artifact — a green GitHub Release does not imply PyPI success because the workflow tags before building
  - If PyPI fails mid-flow, never reuse the broken version number

## Release flow (reminder)

After this PR merges to `main`, force-push `release` to `main`'s tip:
```bash
git push --force origin main:release
```
The workflow will tag `v0.2.1`, create the GitHub Release, and this time the PyPI publish step should succeed.

## Test plan

- [x] `pyproject.toml` has no `pkg @ git+...` style deps anywhere
- [x] Version is `0.2.1` in both sources of truth
- [ ] CI green on this branch (especially Pages workflow using the new direct install)
- [ ] After `release` force-push: `v0.2.1` tag, GitHub Release, **and** `roboharness==0.2.1` on PyPI all present

https://claude.ai/code/session_01WZn9JKchrtxVcPiy92ANgL