### PR TITLE
chore: type-hint/docstring cleanup 2026-04-14

### DIFF
--- a/src/roboharness/evaluate/lerobot_plugin.py
+++ b/src/roboharness/evaluate/lerobot_plugin.py
@@ -98,22 +98,26 @@ class LeRobotEvalReport:
 
     @property
     def n_episodes(self) -> int:
+        """Number of evaluated episodes."""
         return len(self.episodes)
 
     @property
     def success_rate(self) -> float:
+        """Fraction of episodes that succeeded (0.0 if no episodes)."""
         if not self.episodes:
             return 0.0
         return sum(1 for ep in self.episodes if ep.success) / len(self.episodes)
 
     @property
     def mean_reward(self) -> float:
+        """Mean cumulative reward across all episodes (0.0 if no episodes)."""
         if not self.episodes:
             return 0.0
         return sum(ep.total_reward for ep in self.episodes) / len(self.episodes)
 
     @property
     def mean_episode_length(self) -> float:
+        """Mean number of steps per episode (0.0 if no episodes)."""
         if not self.episodes:
             return 0.0
         return sum(ep.episode_length for ep in self.episodes) / len(self.episodes)

--- a/src/roboharness/runner.py
+++ b/src/roboharness/runner.py
@@ -51,18 +51,22 @@ class BatchResult:
 
     @property
     def total_trials(self) -> int:
+        """Total number of trials executed."""
         return len(self.results)
 
     @property
     def successful_trials(self) -> int:
+        """Number of trials that completed with success=True."""
         return sum(1 for r in self.results if r.success)
 
     @property
     def failed_trials(self) -> int:
+        """Number of trials that completed with success=False."""
         return self.total_trials - self.successful_trials
 
     @property
     def success_rate(self) -> float:
+        """Fraction of successful trials (0.0 if no trials)."""
         if self.total_trials == 0:
             return 0.0
         return self.successful_trials / self.total_trials


### PR DESCRIPTION
Tuesday docstring cleanup — adds missing one-line docstrings to public properties that lacked them.

## Changes

- **`src/roboharness/runner.py`** — `BatchResult` properties `total_trials`, `successful_trials`, `failed_trials`, `success_rate` were missing docstrings.
- **`src/roboharness/evaluate/lerobot_plugin.py`** — `LeRobotEvalReport` properties `n_episodes`, `success_rate`, `mean_reward`, `mean_episode_length` were missing docstrings.

No behavioural changes. All 437 tests pass, lint clean.