### PR TITLE
chore: docstring cleanup 2026-04-15

### DIFF
--- a/src/roboharness/evaluate/batch.py
+++ b/src/roboharness/evaluate/batch.py
@@ -25,6 +25,7 @@ class TrialSummary:
     failure_codes: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this trial summary to a JSON-compatible dict."""
         return {
             "report_path": self.report_path,
             "case_id": self.case_id,
@@ -48,6 +49,7 @@ class EvalBatchResult:
     trials: list[TrialSummary] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this batch result to a JSON-compatible dict."""
         return {
             "results_dir": self.results_dir,
             "total_trials": self.total_trials,
@@ -67,6 +69,7 @@ class VariantResult:
     batch: EvalBatchResult
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this variant result to a JSON-compatible dict."""
         return {
             "variant_id": self.variant_id,
             **self.batch.to_dict(),
@@ -80,6 +83,7 @@ class ComparisonResult:
     variants: list[VariantResult] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this comparison result to a JSON-compatible dict."""
         return {
             "variants": [v.to_dict() for v in self.variants],
             "summary": {

--- a/src/roboharness/evaluate/lerobot_plugin.py
+++ b/src/roboharness/evaluate/lerobot_plugin.py
@@ -55,6 +55,7 @@ class EpisodeResult:
     metrics: dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this episode result to a JSON-compatible dict."""
         return {
             "episode_id": self.episode_id,
             "success": self.success,
@@ -123,6 +124,7 @@ class LeRobotEvalReport:
         return sum(ep.episode_length for ep in self.episodes) / len(self.episodes)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this evaluation report to a JSON-compatible dict."""
         return {
             "n_episodes": self.n_episodes,
             "success_rate": self.success_rate,

--- a/src/roboharness/evaluate/result.py
+++ b/src/roboharness/evaluate/result.py
@@ -49,6 +49,7 @@ class AssertionResult:
     message: str = ""
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this assertion result to a JSON-compatible dict."""
         threshold: float | list[float] = (
             list(self.threshold) if isinstance(self.threshold, tuple) else self.threshold
         )
@@ -74,21 +75,26 @@ class EvaluationResult:
 
     @property
     def passed(self) -> list[AssertionResult]:
+        """Assertions that passed."""
         return [r for r in self.results if r.passed]
 
     @property
     def failed(self) -> list[AssertionResult]:
+        """Assertions that failed."""
         return [r for r in self.results if not r.passed]
 
     @property
     def critical_failures(self) -> list[AssertionResult]:
+        """Failed assertions with CRITICAL severity."""
         return [r for r in self.results if not r.passed and r.severity == Severity.CRITICAL]
 
     @property
     def major_failures(self) -> list[AssertionResult]:
+        """Failed assertions with MAJOR severity."""
         return [r for r in self.results if not r.passed and r.severity == Severity.MAJOR]
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this evaluation result to a JSON-compatible dict."""
         passed_count = 0
         failed_count = 0
         critical_count = 0

--- a/src/roboharness/storage/history.py
+++ b/src/roboharness/storage/history.py
@@ -28,10 +28,12 @@ class EvaluationRecord:
     metrics: dict[str, float] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this record to a JSON-compatible dict."""
         return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> EvaluationRecord:
+        """Deserialize an EvaluationRecord from a dict (e.g. loaded from JSONL)."""
         return cls(
             task=data["task"],
             success_rate=data["success_rate"],
@@ -56,6 +58,7 @@ class TrendResult:
     message: str
 
     def to_dict(self) -> dict[str, Any]:
+        """Serialize this trend result to a JSON-compatible dict."""
         return asdict(self)
 
 
@@ -91,6 +94,7 @@ class EvaluationHistory:
 
     @property
     def path(self) -> Path:
+        """Path to the underlying JSONL history file."""
         return self._path
 
     def append(self, record: EvaluationRecord) -> None:


### PR DESCRIPTION
## Summary

Tuesday type-hint/docstring cleanup pass. All changed methods already had return type annotations; this adds the missing one-line docstrings.

- `evaluate/result.py`: `AssertionResult.to_dict`; `EvaluationResult.passed`, `failed`, `critical_failures`, `major_failures` properties; `EvaluationResult.to_dict`
- `evaluate/batch.py`: `TrialSummary.to_dict`, `EvalBatchResult.to_dict`, `VariantResult.to_dict`, `ComparisonResult.to_dict`
- `evaluate/lerobot_plugin.py`: `EpisodeResult.to_dict`, `LeRobotEvalReport.to_dict`
- `storage/history.py`: `EvaluationRecord.to_dict`, `EvaluationRecord.from_dict`, `TrendResult.to_dict`, `EvaluationHistory.path`

**16 lines added across 4 files. No logic changes.**

## Test plan

- [x] `ruff check .` — no issues
- [x] `ruff format --check .` — all files already formatted
- [x] `pytest tests/ --no-cov` — 437 passed, 10 skipped

https://claude.ai/code/session_01UojhNwtL3m3HyjTEA12ECd