### PR TITLE
chore: error handling cleanup 2026-04-16

### DIFF
--- a/src/roboharness/wrappers/gymnasium_wrapper.py
+++ b/src/roboharness/wrappers/gymnasium_wrapper.py
@@ -407,4 +407,9 @@ def _to_float(value: Any) -> float:
     try:
         return float(value)
     except (TypeError, ValueError):
+        logger.warning(
+            "Cannot convert reward value of type %s to float; using 0.0. "
+            "Pass a numeric type (int, float, np.ndarray, or tensor).",
+            type(value).__name__,
+        )
         return 0.0


### PR DESCRIPTION
## Thursday error-handling cleanup

**Category:** Error handling (Thursday rotation)

### Changes

| File | Line | Change |
|------|------|--------|
| `src/roboharness/wrappers/gymnasium_wrapper.py` | 409–415 | `_to_float()` now emits `logger.warning` when `float(value)` raises `TypeError`/`ValueError` before returning the `0.0` fallback. Previously the failure was completely silent, making it impossible to diagnose "why are all my rewards 0?" bugs when an unexpected reward type was passed. |

### What was audited

Scanned all `except` blocks in `src/`:

- `runner.py:185` — `except Exception as exc` in thread-pool future handler: logs error + converts to failed `TrialResult`. **OK.**
- `gymnasium_wrapper.py:132` — `except Exception` in frame capture: logs at DEBUG with `exc_info=True`. **OK.**
- `evaluate/lerobot_plugin.py:165` — `except Exception` in render capture: logs at DEBUG with `exc_info=True`. **OK.**
- `_utils.py:27` — `except ImportError` for PIL: logs warning + saves `.npy` fallback. **OK.**
- `storage/history.py:76` — `except (FileNotFoundError, TimeoutExpired)` in git-hash lookup: documented "returns empty string if unavailable". **OK.**
- `evaluate/assertions.py:108` — `except (TypeError, ValueError)` in metric extraction: returns `None` (correct sentinel for "metric not convertible"). **OK.**
- `gymnasium_wrapper.py:409` — `except (TypeError, ValueError)` in `_to_float`: **fixed** (added warning log).

### Verification

- `ruff check .` — clean
- `ruff format --check .` — clean
- `pytest` — 453 passed, 12 skipped