### PR TITLE
fix(tests): gracefully skip MuJoCo live validation when OpenGL is broken

### DIFF
--- a/tests/test_mujoco_grasp_live_validation.py
+++ b/tests/test_mujoco_grasp_live_validation.py
@@ -29,7 +29,10 @@ from roboharness.evaluate.result import Verdict
 
 def _require_mujoco_rendering() -> None:
     """Skip when MuJoCo rendering is unavailable in the current environment."""
-    mujoco = pytest.importorskip("mujoco")
+    try:
+        import mujoco
+    except Exception as exc:
+        pytest.skip(f"MuJoCo not available: {exc}")
     gl_backend = os.environ.get("MUJOCO_GL", "").lower()
     has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
     if not gl_backend and not has_display:


### PR DESCRIPTION
## Summary

`pytest.importorskip(\"mujoco\")` only catches `ImportError`, but MuJoCo can fail to initialize with `AttributeError` when the OpenGL/Mesa backend is broken (e.g., `'NoneType' object has no attribute 'glGetError'`).

This change wraps the import in a `try/except Exception` and calls `pytest.skip(...)` instead, so the live-validation test does not fail in environments where MuJoCo is installed but rendering is unavailable.

## Test plan

- `pytest tests/test_mujoco_grasp_live_validation.py -q` now skips gracefully instead of failing with `AttributeError`.