### PR TITLE
docs: link to showcase repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@
 | **[SONIC Planner](#sonic-planner)** | Standalone GEAR-SONIC planner demo on G1 | [Live](https://miaodx.com/roboharness/sonic-planner/) | `python examples/sonic_locomotion.py --report` |
 | **[SONIC Motion Tracking](#sonic-motion-tracking)** | Real encoder+decoder tracking demo on G1 | [Live](https://miaodx.com/roboharness/sonic/) | `python examples/sonic_tracking.py --report` |
 
+## Showcase Repository
+
+See real projects that consume roboharness as a pip dependency:
+
+- **[LeRobot Evaluation](https://github.com/roboharness/showcase/tree/main/lerobot-eval)** — visual regression testing for robot policies
+- **[GR00T WBC](https://github.com/roboharness/showcase/tree/main/groot-wbc)** — whole-body control integration
+
+Each showcase is self-contained, runs with `./run.sh`, and supports smoke mode for fast CI validation.
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Adds a **Showcase Repository** section to the README linking to the two approved showcases:

- [lerobot-eval](https://github.com/roboharness/showcase/tree/main/lerobot-eval)
- [groot-wbc](https://github.com/roboharness/showcase/tree/main/groot-wbc)

This helps users discover that roboharness is designed to be consumed as a pip dependency in external projects.