### PR TITLE
chore: dependency & config hygiene 2026-04-18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Build package
         run: |
-          pip install build
+          pip install "build>=1.0"
           python -m build
 
       - name: Verify package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,14 @@ demo = [
 wbc = [
     "pin>=3.0",
     "pin-pink>=0.11",
-    "qpsolvers[quadprog]",
+    "qpsolvers[quadprog]>=3.0",
 ]
 lerobot = [
-    "lerobot",
+    "lerobot>=0.1",
     "gymnasium>=0.29",
     "mujoco>=3.0",
-    "Pillow",
-    "torch",
+    "Pillow>=9.0",
+    "torch>=2.0",
 ]
 dev = [
     "pytest>=7.0",


### PR DESCRIPTION
## Summary

Saturday health check — dependencies & config hygiene.

- `pyproject.toml` `lerobot` extra: `Pillow` → `Pillow>=9.0` (consistent with `demo`/`dev` extras), `lerobot` → `lerobot>=0.1`, `torch` → `torch>=2.0`
- `pyproject.toml` `wbc` extra: `qpsolvers[quadprog]` → `qpsolvers[quadprog]>=3.0` (adds missing lower bound)
- `.github/workflows/release.yml`: `pip install build` → `pip install "build>=1.0"` (avoids pre-1.0 API)

## Test plan

- [x] `ruff check .` — passed
- [x] `ruff format --check .` — passed
- [x] `pytest --no-cov` — 480 passed, 12 skipped, 2 pre-existing mujoco-missing failures (unrelated to this change)

https://claude.ai/code/session_01QQCEAU1UTuSQGZRFehwgsR