### PR TITLE
Add demo matrix and sonic-planner site support; add steering docs, validation script, and tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Human review gates for agent-sensitive surfaces
+* @MiaoDX
+
+README.md @MiaoDX
+AGENTS.md @MiaoDX
+CLAUDE.md @MiaoDX
+pyproject.toml @MiaoDX
+CHANGELOG.md @MiaoDX
+.github/workflows/* @MiaoDX
+constraints/demo_matrix.toml @MiaoDX
+docs/steering/* @MiaoDX
+docs/release/* @MiaoDX
+examples/_mujoco_grasp_wedge.py @MiaoDX
+tests/test_mujoco_grasp_seeded_corpus.py @MiaoDX

--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -33,7 +33,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           mkdir -p _site/grasp _site/g1-reach _site/g1-loco \
-                   _site/g1-native-groot _site/g1-native-sonic _site/sonic
+                   _site/g1-native-groot _site/g1-native-sonic _site/sonic-planner _site/sonic
           BASE=https://miaodx.com/roboharness
           curl -fsSL "$BASE/"           -o _site/index.html
           curl -fsSL "$BASE/grasp/"     -o _site/grasp/index.html
@@ -41,6 +41,7 @@ jobs:
           curl -fsSL "$BASE/g1-loco/"   -o _site/g1-loco/index.html
           curl -fsSL "$BASE/g1-native-groot/" -o _site/g1-native-groot/index.html
           curl -fsSL "$BASE/g1-native-sonic/" -o _site/g1-native-sonic/index.html
+          curl -fsSL "$BASE/sonic-planner/" -o _site/sonic-planner/index.html
           curl -fsSL "$BASE/sonic/"     -o _site/sonic/index.html
 
       - uses: actions/setup-python@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 This file defines the default operating playbook for coding agents working in this repository.
 Its scope is the entire repo tree rooted at this directory.
 
+## Steering priority
+
+Before implementing broad changes, read `docs/steering/current.md` for the active milestone and non-goals.
+
 ## 0) First-read policy (mandatory)
 
 Before running any command, read in this order:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing! Roboharness is in early development
 
 ### Reporting Bugs
 
-- Open an issue on [GitHub Issues](https://github.com/MiaoDX/RobotHarness/issues)
+- Open an issue on [GitHub Issues](https://github.com/MiaoDX/roboharness/issues)
 - Include your Python version, OS, and simulator versions
 - Provide a minimal reproducible example if possible
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Approval/evidence harness for unattended robot code changes.
 
-[![CI](https://github.com/MiaoDX/RobotHarness/actions/workflows/ci.yml/badge.svg)](https://github.com/MiaoDX/RobotHarness/actions/workflows/ci.yml)
+[![CI](https://github.com/MiaoDX/roboharness/actions/workflows/ci.yml/badge.svg)](https://github.com/MiaoDX/roboharness/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/roboharness)](https://pypi.org/project/roboharness/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
@@ -51,8 +51,8 @@ checkout.
 This path exercises the shipped MuJoCo approval wedge from this repository.
 
 ```bash
-git clone https://github.com/MiaoDX/RobotHarness.git
-cd RobotHarness
+git clone https://github.com/MiaoDX/roboharness.git
+cd roboharness
 python -m pip install -e ".[demo]"
 python examples/mujoco_grasp.py --report
 ```

--- a/constraints/demo_matrix.toml
+++ b/constraints/demo_matrix.toml
@@ -1,0 +1,34 @@
+[[demo]]
+id = "grasp"
+entry = "examples/mujoco_grasp.py"
+artifact_dir = "grasp"
+
+[[demo]]
+id = "g1-reach"
+entry = "examples/g1_wbc_reach.py"
+artifact_dir = "g1-reach"
+
+[[demo]]
+id = "g1-loco"
+entry = "examples/lerobot_g1.py"
+artifact_dir = "g1-loco"
+
+[[demo]]
+id = "g1-native-groot"
+entry = "examples/lerobot_g1_native.py --controller groot"
+artifact_dir = "g1-native-groot"
+
+[[demo]]
+id = "g1-native-sonic"
+entry = "examples/lerobot_g1_native.py --controller sonic"
+artifact_dir = "g1-native-sonic"
+
+[[demo]]
+id = "sonic-planner"
+entry = "examples/sonic_locomotion.py"
+artifact_dir = "sonic-planner"
+
+[[demo]]
+id = "sonic"
+entry = "examples/sonic_tracking.py"
+artifact_dir = "sonic"

--- a/docs/steering/current.md
+++ b/docs/steering/current.md
@@ -1,0 +1,28 @@
+# Steering Cockpit (Current)
+
+## North Star
+
+Trust compression for unattended robot-code changes.
+
+## Current Milestone
+
+**v0.3 — Trust Loop (MuJoCo contract-first approval loop)**
+
+## Must Do
+
+- Seed and maintain a deterministic evaluator corpus for the MuJoCo wedge.
+- Keep `CONTRACT_INVALID` behavior fail-closed.
+- Ensure `AMBIGUOUS` results never self-promote to `PASS`.
+- Keep migration `PASS` gated behind explicit baseline blessing.
+- Keep release truth aligned across repo version, GitHub Releases, and PyPI.
+
+## Must Not Do (During v0.3)
+
+- Add new simulator backends.
+- Split into new showcase repos.
+- Expand SONIC backend scope without real-model validation evidence.
+- Prioritize outreach/docs polish over trust-loop calibration.
+
+## Review Gate
+
+Changes that affect approval semantics, release semantics, or strategic direction must receive human review before merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,10 @@ dev = [
 roboharness = "roboharness.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/MiaoDX/RobotHarness"
-Repository = "https://github.com/MiaoDX/RobotHarness"
-Issues = "https://github.com/MiaoDX/RobotHarness/issues"
-Documentation = "https://github.com/MiaoDX/RobotHarness/tree/main/docs"
+Homepage = "https://github.com/MiaoDX/roboharness"
+Repository = "https://github.com/MiaoDX/roboharness"
+Issues = "https://github.com/MiaoDX/roboharness/issues"
+Documentation = "https://github.com/MiaoDX/roboharness/tree/main/docs"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/scripts/validate_demo_matrix.py
+++ b/scripts/validate_demo_matrix.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib
+
+
+def main() -> int:
+    matrix_path = Path("constraints/demo_matrix.toml")
+    if not matrix_path.exists():
+        print(f"missing: {matrix_path}")
+        return 1
+
+    data = tomllib.loads(matrix_path.read_text())
+    demos = data.get("demo", [])
+    if not demos:
+        print("demo matrix must contain at least one [[demo]] entry")
+        return 1
+
+    seen_ids: set[str] = set()
+    for index, demo in enumerate(demos, start=1):
+        for required in ("id", "entry", "artifact_dir"):
+            if not demo.get(required):
+                print(f"demo #{index} missing required key: {required}")
+                return 1
+        demo_id = demo["id"]
+        if demo_id in seen_ids:
+            print(f"duplicate demo id: {demo_id}")
+            return 1
+        seen_ids.add(demo_id)
+
+    if "sonic-planner" not in seen_ids:
+        print("demo matrix must include sonic-planner")
+        return 1
+
+    print(f"demo matrix ok ({len(demos)} demos)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_demo_matrix.py
+++ b/tests/test_demo_matrix.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib
+
+
+def _matrix_ids() -> set[str]:
+    data = tomllib.loads(Path("constraints/demo_matrix.toml").read_text())
+    return {demo["id"] for demo in data["demo"]}
+
+
+def test_demo_matrix_includes_expected_ids() -> None:
+    expected = {
+        "grasp",
+        "g1-reach",
+        "g1-loco",
+        "g1-native-groot",
+        "g1-native-sonic",
+        "sonic-planner",
+        "sonic",
+    }
+    assert _matrix_ids() == expected
+
+
+def test_hf_manual_fetch_keeps_sonic_planner_in_sync() -> None:
+    workflow = Path(".github/workflows/hf-space.yml").read_text()
+    assert "_site/sonic-planner" in workflow
+    assert "$BASE/sonic-planner/" in workflow

--- a/tests/test_release_truth.py
+++ b/tests/test_release_truth.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib
+
+
+def test_version_is_synced_between_pyproject_and_package() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    package_init = Path("src/roboharness/__init__.py").read_text()
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', package_init)
+    assert match is not None
+    assert pyproject["project"]["version"] == match.group(1)
+
+
+def test_project_urls_point_to_lowercase_repo() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    urls = pyproject["project"]["urls"]
+    assert "MiaoDX/roboharness" in urls["Homepage"]
+    assert "MiaoDX/roboharness" in urls["Repository"]
+    assert "MiaoDX/roboharness/issues" in urls["Issues"]
+    assert "MiaoDX/roboharness/tree/main/docs" in urls["Documentation"]


### PR DESCRIPTION
### Motivation

- Introduce an explicit demo matrix and ensure the new `sonic-planner` demo is tracked and deployed as part of the HF Space workflow.
- Centralize steering guidance and reviewer ownership for agent-sensitive surfaces to enforce human review gates and development priorities.
- Normalize repository URLs/branding and add automated checks to keep release metadata and demo configuration consistent.

### Description

- Add `constraints/demo_matrix.toml` listing demos including `sonic-planner` and add `scripts/validate_demo_matrix.py` to lint the matrix file.
- Update the HF Space workflow `(.github/workflows/hf-space.yml)` to fetch and upload the `sonic-planner` site artifact and adjust local site paths.
- Add human review mapping in `.github/CODEOWNERS` and new steering guidance in `docs/steering/current.md` and an agent steering hint in `AGENTS.md`.
- Rename repository references to lowercase `roboharness` in `README.md`, `CONTRIBUTING.md`, and `pyproject.toml`, and add tests `tests/test_demo_matrix.py` and `tests/test_release_truth.py` that assert matrix contents, workflow sync, and release-truth alignment.

### Testing

- Ran the test suite with `pytest -q`, and the added tests `tests/test_demo_matrix.py` and `tests/test_release_truth.py` passed.
- Executed the demo matrix validator with `python scripts/validate_demo_matrix.py`, which returned success (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c4414374832db0b1b99e834918e2)