### PR TITLE
chore: dead code cleanup 2026-04-21

### DIFF
--- a/examples/lerobot_g1_native.py
+++ b/examples/lerobot_g1_native.py
@@ -133,7 +133,7 @@ def _load_controller(name: str) -> Any:
             from roboharness.controllers.locomotion import GrootLocomotionController
 
             return GrootLocomotionController()
-        elif name == "sonic":
+        if name == "sonic":
             from roboharness.controllers.locomotion import SonicLocomotionController
 
             return SonicLocomotionController()

--- a/src/roboharness/backends/visualizer.py
+++ b/src/roboharness/backends/visualizer.py
@@ -175,18 +175,17 @@ class MeshcatVisualizer:
 
         if geom_type == _PLANE:
             return g.Box([2.0, 2.0, 0.001])
-        elif geom_type == _SPHERE:
+        if geom_type == _SPHERE:
             return g.Sphere(float(size[0]))
-        elif geom_type in (_CAPSULE, _CYLINDER):
+        if geom_type in (_CAPSULE, _CYLINDER):
             radius = float(size[0])
             half_length = float(size[1])
             return g.Cylinder(2 * half_length, radius)
-        elif geom_type == _BOX:
+        if geom_type == _BOX:
             return g.Box([2 * float(size[0]), 2 * float(size[1]), 2 * float(size[2])])
-        elif geom_type == _MESH and geom_id >= 0:
+        if geom_type == _MESH and geom_id >= 0:
             return self._make_mesh_geometry(geom_id)
-        else:
-            return None
+        return None
 
     def _make_mesh_geometry(self, geom_id: int) -> Any:
         """Extract mesh vertices/faces from MuJoCo model for a mesh geom."""


### PR DESCRIPTION
## Summary

Monday dead-code cleanup — removes superfluous `elif` after `return` in two files (ruff RET505, safe auto-fix).

- `src/roboharness/backends/visualizer.py`: converted `elif` chain to flat `if` sequence in geometry-building method — each branch returns, so `elif` was structurally redundant; also collapses final `else: return None` to a bare `return None`
- `examples/lerobot_g1_native.py`: `elif name == "sonic"` → `if name == "sonic"` inside `_load_controller`, where the preceding `if` branch always returns

No behavioral changes. All 506 tests pass, ruff + mypy clean.