### PR TITLE
ci: create Hugging Face Space before sync

### DIFF
--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -59,11 +59,19 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python -c "
+          import os
           from huggingface_hub import HfApi
-          api = HfApi()
+          repo_id = 'miaodongxu/roboharness-demo'
+          api = HfApi(token=os.environ['HF_TOKEN'])
+          api.create_repo(
+              repo_id=repo_id,
+              repo_type='space',
+              space_sdk='static',
+              exist_ok=True,
+          )
           api.upload_folder(
               folder_path='_site',
-              repo_id='miaodongxu/roboharness-demo',
+              repo_id=repo_id,
               repo_type='space',
           )
           "


### PR DESCRIPTION
## Summary
- Create the target Hugging Face Space as a static Space when it is missing.
- Reuse the repo id variable for both creation and upload.
- Pass HF_TOKEN explicitly to HfApi.

## Validation
- Previous sync now authenticates but fails with 404 because miaodongxu/roboharness-demo does not exist yet.
- Workflow-only fix; PR CI will validate the repo gates.