### PR TITLE
fix: make HF static demo links explicit

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -40,7 +40,7 @@
 <p class="subtitle">Auto-generated from CI on every push to <code>main</code>.
 Each demo runs headless in GitHub Actions and produces visual checkpoint captures for planner, tracking, and integration paths.</p>
 <div class="demos">
-  <a class="demo-card" href="grasp/">
+  <a class="demo-card" href="grasp/index.html">
     <h2>MuJoCo Grasp</h2>
     <div>
       <span class="tag tag-cpu">CPU</span>
@@ -50,7 +50,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     4 checkpoints with interactive 3D scenes.</p>
     <div class="meta">MuJoCo inline model &middot; 3 cameras &middot; position control</div>
   </a>
-  <a class="demo-card humanoid" href="g1-reach/">
+  <a class="demo-card humanoid" href="g1-reach/index.html">
     <h2>G1 WBC Reach</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>
@@ -61,7 +61,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     differential-IK keeps balance while both arms reach 3D targets.</p>
     <div class="meta">MuJoCo Menagerie &middot; 4 cameras &middot; WbcIkController</div>
   </a>
-  <a class="demo-card loco" href="g1-loco/">
+  <a class="demo-card loco" href="g1-loco/index.html">
     <h2>G1 Locomotion</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>
@@ -72,7 +72,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     Real 29-DOF model from HuggingFace with multi-camera captures.</p>
     <div class="meta">LeRobot HF model &middot; multi-camera &middot; GrootLocomotionController</div>
   </a>
-  <a class="demo-card" href="g1-native-groot/" style="border-left-color: #43a047;">
+  <a class="demo-card" href="g1-native-groot/index.html" style="border-left-color: #43a047;">
     <h2>G1 Native LeRobot (GR00T)</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>
@@ -84,7 +84,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     creation driven by GR00T Balance + Walk through <code>VectorEnvAdapter</code>.</p>
     <div class="meta">LeRobot native &middot; GR00T locomotion &middot; DDS-ready</div>
   </a>
-  <a class="demo-card sonic" href="g1-native-sonic/">
+  <a class="demo-card sonic" href="g1-native-sonic/index.html">
     <h2>G1 Native LeRobot (SONIC)</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>
@@ -96,7 +96,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     the SONIC planner for a controller-level comparison report.</p>
     <div class="meta">LeRobot native &middot; SONIC planner &middot; DDS-ready</div>
   </a>
-  <a class="demo-card sonic" href="sonic-planner/">
+  <a class="demo-card sonic" href="sonic-planner/index.html">
     <h2>SONIC Planner</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>
@@ -107,7 +107,7 @@ Each demo runs headless in GitHub Actions and produces visual checkpoint capture
     drive full-body pose trajectories through <code>planner_sonic.onnx</code>.</p>
     <div class="meta">1 ONNX model &middot; 29-DOF &middot; SonicLocomotionController</div>
   </a>
-  <a class="demo-card sonic" href="sonic/">
+  <a class="demo-card sonic" href="sonic/index.html">
     <h2>SONIC Motion Tracking</h2>
     <div>
       <span class="tag tag-humanoid">Humanoid</span>

--- a/tests/contract/test_demo_matrix.py
+++ b/tests/contract/test_demo_matrix.py
@@ -30,3 +30,10 @@ def test_hf_manual_fetch_keeps_sonic_planner_in_sync() -> None:
     workflow = Path(".github/workflows/hf-space.yml").read_text()
     assert "_site/sonic-planner" in workflow
     assert "$BASE/sonic-planner/" in workflow
+
+
+def test_landing_page_uses_hf_static_compatible_demo_links() -> None:
+    page = Path(".github/pages/index.html").read_text()
+    for demo_id in _matrix_ids():
+        assert f'href="{demo_id}/index.html"' in page
+        assert f'href="{demo_id}/"' not in page


### PR DESCRIPTION
## Summary
- Change demo card links from directory URLs to explicit index.html paths.
- Add a regression test so HF static-compatible links stay in the landing page.

## Root cause
Hugging Face static Spaces redirect directory URLs like /g1-reach/ to huggingface.co/g1-reach, which returns 404. The files are available at /g1-reach/index.html.

## Validation
- uv run pytest -q tests/contract/test_demo_matrix.py --no-cov
- Verified existing deployed /<demo>/index.html URLs return 200 on the HF static host.