### PR TITLE
ci: use Hugging Face hub-sync for Space mirror

### DIFF
--- a/.github/workflows/hf-space.yml
+++ b/.github/workflows/hf-space.yml
@@ -36,42 +36,23 @@ jobs:
                    _site/g1-native-groot _site/g1-native-sonic _site/sonic-planner _site/sonic
           BASE=https://miaodx.com/roboharness
           curl -fsSL "$BASE/"           -o _site/index.html
-          curl -fsSL "$BASE/grasp/"     -o _site/grasp/index.html
-          curl -fsSL "$BASE/g1-reach/"  -o _site/g1-reach/index.html
-          curl -fsSL "$BASE/g1-loco/"   -o _site/g1-loco/index.html
-          curl -fsSL "$BASE/g1-native-groot/" -o _site/g1-native-groot/index.html
-          curl -fsSL "$BASE/g1-native-sonic/" -o _site/g1-native-sonic/index.html
-          curl -fsSL "$BASE/sonic-planner/" -o _site/sonic-planner/index.html
-          curl -fsSL "$BASE/sonic/"     -o _site/sonic/index.html
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install huggingface_hub
-        run: pip install "huggingface_hub>=0.20"
+          curl -fsSL "$BASE/grasp/index.html"     -o _site/grasp/index.html
+          curl -fsSL "$BASE/g1-reach/index.html"  -o _site/g1-reach/index.html
+          curl -fsSL "$BASE/g1-loco/index.html"   -o _site/g1-loco/index.html
+          curl -fsSL "$BASE/g1-native-groot/index.html" -o _site/g1-native-groot/index.html
+          curl -fsSL "$BASE/g1-native-sonic/index.html" -o _site/g1-native-sonic/index.html
+          curl -fsSL "$BASE/sonic-planner/index.html" -o _site/sonic-planner/index.html
+          curl -fsSL "$BASE/sonic/index.html"     -o _site/sonic/index.html
 
       - name: Add Space metadata
         run: cp hf-space/README.md _site/README.md
 
-      - name: Push to HuggingFace Space
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          python -c "
-          import os
-          from huggingface_hub import HfApi
-          repo_id = 'miaodongxu/roboharness-demo'
-          api = HfApi(token=os.environ['HF_TOKEN'])
-          api.create_repo(
-              repo_id=repo_id,
-              repo_type='space',
-              space_sdk='static',
-              exist_ok=True,
-          )
-          api.upload_folder(
-              folder_path='_site',
-              repo_id=repo_id,
-              repo_type='space',
-          )
-          "
+      - name: Mirror site to Hugging Face Space
+        uses: huggingface/hub-sync@v0.1.0
+        with:
+          github_repo_id: MiaoDX/roboharness
+          subdirectory: _site
+          huggingface_repo_id: miaodongxu/roboharness-demo
+          hf_token: ${{ secrets.HF_TOKEN }}
+          repo_type: space
+          space_sdk: static

--- a/tests/contract/test_demo_matrix.py
+++ b/tests/contract/test_demo_matrix.py
@@ -29,7 +29,18 @@ def test_demo_matrix_includes_expected_ids() -> None:
 def test_hf_manual_fetch_keeps_sonic_planner_in_sync() -> None:
     workflow = Path(".github/workflows/hf-space.yml").read_text()
     assert "_site/sonic-planner" in workflow
-    assert "$BASE/sonic-planner/" in workflow
+    assert "$BASE/sonic-planner/index.html" in workflow
+
+
+def test_hf_sync_uses_official_mirror_action() -> None:
+    workflow = Path(".github/workflows/hf-space.yml").read_text()
+    assert "uses: huggingface/hub-sync@v0.1.0" in workflow
+    assert "subdirectory: _site" in workflow
+    assert "huggingface_repo_id: miaodongxu/roboharness-demo" in workflow
+    assert "repo_type: space" in workflow
+    assert "space_sdk: static" in workflow
+    assert "HfApi" not in workflow
+    assert "upload_folder" not in workflow
 
 
 def test_landing_page_uses_hf_static_compatible_demo_links() -> None:


### PR DESCRIPTION
## Summary
- Replace the custom Python HfApi upload with the official huggingface/hub-sync action.
- Mirror the generated _site artifact as a static Space via the action subdirectory input.
- Keep manual workflow dispatch fetches on explicit index.html URLs.
- Add contract coverage that prevents reintroducing the custom uploader.

## Validation
- uv run pytest -q tests/contract/test_demo_matrix.py --no-cov
- uv run ruff check .
- uv run ruff format --check .

## Notes
- uv run mypy src/ currently fails on an unrelated local typing issue in src/roboharness/robots/unitree_g1/locomotion.py:1027.