### PR TITLE
Release v0.3.0 prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ Use this when you are adding roboharness to an existing codebase. The published
 wheel installs the library and the `roboharness` CLI, not the repo's
 `examples/` directory.
 
+For the latest code, prefer installing from Git with `uv`:
+
+```bash
+uv pip install "roboharness @ git+https://github.com/MiaoDX/roboharness.git"
+roboharness --help
+```
+
+The PyPI package can briefly trail the current README because publishing is
+handled separately. If you need the latest published release instead, use:
+
 ```bash
 pip install roboharness
 roboharness --help
@@ -101,12 +111,15 @@ That is the job of the MuJoCo wedge today.
 ## Installation Matrix
 
 ```bash
-pip install roboharness                  # core (numpy only)
-pip install roboharness[demo]            # MuJoCo, Meshcat, Gymnasium, Rerun, Pillow
-pip install roboharness[demo,wbc]        # + whole-body control (Pinocchio, Pink)
-pip install roboharness[lerobot]         # LeRobot evaluation path
-pip install roboharness[dev]             # test/lint/type deps
+uv pip install "roboharness @ git+https://github.com/MiaoDX/roboharness.git"          # latest Git core
+uv pip install "roboharness[demo] @ git+https://github.com/MiaoDX/roboharness.git"    # MuJoCo, Meshcat, Gymnasium, Rerun, Pillow
+uv pip install "roboharness[demo,wbc] @ git+https://github.com/MiaoDX/roboharness.git" # + whole-body control (Pinocchio, Pink)
+uv pip install "roboharness[lerobot] @ git+https://github.com/MiaoDX/roboharness.git" # LeRobot evaluation path
+uv pip install "roboharness[dev] @ git+https://github.com/MiaoDX/roboharness.git"     # test/lint/type deps
 ```
+
+For PyPI installs, replace the `uv pip install "... @ git+..."` form with the
+same extra on the published package, for example `pip install roboharness[demo]`.
 
 ## Progressive Disclosure
 

--- a/src/roboharness/robots/unitree_g1/locomotion.py
+++ b/src/roboharness/robots/unitree_g1/locomotion.py
@@ -1024,7 +1024,7 @@ class SonicLocomotionController:
             aligned_ref_rot = self._tracking_heading_alignment @ ref_rot
             base_to_ref_rot = base_rot.T @ aligned_ref_rot
             windows.append(_rotation_matrix_to_sixd(base_to_ref_rot))
-        return np.concatenate(windows).astype(np.float32)
+        return cast("npt.NDArray[np.float32]", np.concatenate(windows).astype(np.float32))
 
     def _append_tracking_history_sample(
         self,


### PR DESCRIPTION
## Summary
- Prefer `uv` Git installs in the README for users who need the latest code before PyPI catches up.
- Fix one NumPy typing inference issue in the SONIC locomotion tracking path so `mypy src/` passes.

## Release target
- PyPI currently reports `0.2.1`.
- Repo version is already `0.3.0` in `pyproject.toml` and `src/roboharness/__init__.py`.
- After this PR lands, advancing the `release` branch should publish `v0.3.0`.

## Validation
- `uv pip install -e ".[dev]"`
- `uv run python -c "import pytest_cov; print('pytest-cov ok')"`
- `uv run pytest -q` — 508 passed, 13 skipped, coverage 93.21%
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run --with build python -m build` — built `roboharness-0.3.0.tar.gz` and wheel
- Wheel smoke import printed `0.3.0`