### PR TITLE
Fix core wheel import for v0.3.1 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "roboharness"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Visual Testing Harness for AI Coding Agents in Robot Simulation"
 readme = "README.md"
 license = "MIT"

--- a/src/roboharness/__init__.py
+++ b/src/roboharness/__init__.py
@@ -1,6 +1,6 @@
 """Roboharness: A Visual Testing Harness for AI Coding Agents in Robot Simulation."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from roboharness.core.capture import CaptureResult
 from roboharness.core.checkpoint import Checkpoint, CheckpointStore

--- a/src/roboharness/evaluate/__init__.py
+++ b/src/roboharness/evaluate/__init__.py
@@ -13,7 +13,6 @@ from roboharness.evaluate.batch import (
 )
 from roboharness.evaluate.constraints import load_constraints, save_constraints
 from roboharness.evaluate.defaults import GRASP_DEFAULTS
-from roboharness.evaluate.lerobot_env import create_native_env
 from roboharness.evaluate.lerobot_plugin import (
     EpisodeResult,
     LeRobotEvalConfig,
@@ -57,3 +56,11 @@ __all__ = [
     "load_constraints",
     "save_constraints",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "create_native_env":
+        from roboharness.evaluate.lerobot_env import create_native_env
+
+        return create_native_env
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/roboharness/evaluate/lerobot_plugin.py
+++ b/src/roboharness/evaluate/lerobot_plugin.py
@@ -31,7 +31,6 @@ from typing import Any
 
 import numpy as np
 
-from roboharness.evaluate.lerobot_env import create_native_env
 from roboharness.evaluate.lerobot_policy_adapter import load_lerobot_policy
 from roboharness.evaluate.protocol import PolicyAdapter
 
@@ -150,6 +149,13 @@ PolicyFn = Callable[[np.ndarray], np.ndarray]
 
 #: Type alias for a custom metrics function: (episode_rewards, last_info) → metrics dict.
 MetricsFn = Callable[[list[float], dict[str, Any]], dict[str, float]]
+
+
+def create_native_env(*args: Any, **kwargs: Any) -> Any:
+    """Create a LeRobot native env without importing optional deps at package import time."""
+    from roboharness.evaluate.lerobot_env import create_native_env as _create_native_env
+
+    return _create_native_env(*args, **kwargs)
 
 
 def _save_checkpoint_screenshot(

--- a/tests/unit/test_package_imports.py
+++ b/tests/unit/test_package_imports.py
@@ -1,0 +1,38 @@
+"""Package import boundary tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_core_package_import_does_not_require_gym() -> None:
+    """The core wheel must import without optional simulator extras installed."""
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+
+        class BlockGymImports(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "gym" or fullname.startswith("gym."):
+                    raise ModuleNotFoundError(f"No module named {fullname!r}")
+                if fullname == "gymnasium" or fullname.startswith("gymnasium."):
+                    raise ModuleNotFoundError(f"No module named {fullname!r}")
+                return None
+
+
+        sys.meta_path.insert(0, BlockGymImports())
+
+        import roboharness
+        from roboharness import AssertionEngine, Harness
+
+        assert roboharness.__version__
+        assert AssertionEngine is not None
+        assert Harness is not None
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
## Summary
- Bump the release target from `0.3.0` to `0.3.1` because `v0.3.0` already tagged/released before PyPI upload.
- Keep `import roboharness` free of optional Gym/Gymnasium dependencies by lazily importing the LeRobot native env helper.
- Preserve the existing `roboharness.evaluate.lerobot_plugin.create_native_env` patch point with a lazy wrapper.
- Add a regression test that blocks `gym` and `gymnasium` imports and verifies core package import still works.

## Why
The `v0.3.0` release workflow created the tag and GitHub Release, then failed in wheel verification before PyPI publish:

```text
ModuleNotFoundError: No module named 'gymnasium'
ModuleNotFoundError: No module named 'gym'
```

PyPI still reports `0.2.1`; per the release runbook, the next publish attempt should use the next patch version.

## Validation
- `uv pip install -e ".[dev]"`
- `uv run pytest --no-cov -q tests/unit/test_package_imports.py`
- `uv run pytest --no-cov -q tests/unit/evaluate/test_lerobot_eval_plugin.py::TestEvaluateLerobotPolicy::test_delegates_to_evaluate_policy tests/unit/test_package_imports.py`
- `uv run python -c "import pytest_cov; print('pytest-cov ok')"`
- `uv run pytest -q` — 509 passed, 13 skipped, coverage 92.95%
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run --with build python -m build --outdir /tmp/tmp.uIvDW1tGC4` — built `roboharness-0.3.1.tar.gz` and wheel
- Isolated wheel install/import printed `0.3.1`