### PR TITLE
fix(ci): restore Docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.12-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         libosmesa6-dev \
-        libgl1-mesa-glx \
+        libgl1 \
         git \
     && rm -rf /var/lib/apt/lists/*
 
@@ -26,6 +26,7 @@ ENV UV_SYSTEM_PYTHON=1
 # Copy only dependency metadata first (for layer caching)
 WORKDIR /opt/roboharness
 COPY pyproject.toml .
+COPY README.md .
 RUN mkdir -p src/roboharness && \
     echo '__version__ = "0.0.0"' > src/roboharness/__init__.py
 

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -33,6 +33,7 @@ ENV UV_SYSTEM_PYTHON=1
 # Copy only dependency metadata first (for layer caching)
 WORKDIR /opt/roboharness
 COPY pyproject.toml .
+COPY README.md .
 RUN mkdir -p src/roboharness && \
     echo '__version__ = "0.0.0"' > src/roboharness/__init__.py
 

--- a/tests/contract/test_dockerfiles.py
+++ b/tests/contract/test_dockerfiles.py
@@ -1,0 +1,27 @@
+"""Contract tests for CI Docker image definitions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _dockerfile(name: str) -> str:
+    return (REPO_ROOT / name).read_text()
+
+
+def test_cpu_dockerfile_uses_current_debian_gl_package() -> None:
+    dockerfile = _dockerfile("Dockerfile")
+
+    assert "libgl1-mesa-glx" not in dockerfile
+    assert "libgl1" in dockerfile
+
+
+def test_dockerfiles_copy_readme_before_editable_install() -> None:
+    for name in ("Dockerfile", "Dockerfile.gpu"):
+        dockerfile = _dockerfile(name)
+        readme_index = dockerfile.index("COPY README.md .")
+        install_index = dockerfile.index('RUN uv pip install -e "')
+
+        assert readme_index < install_index


### PR DESCRIPTION
## Summary
- Replace the removed Debian `libgl1-mesa-glx` package with `libgl1` in the CPU Docker image build.
- Copy `README.md` into both Docker metadata install layers so Hatchling can validate `readme = "README.md"` during editable installs.
- Add contract tests to keep the Dockerfile metadata assumptions from regressing.

## Root Cause
The failing `Build CI Docker Image` workflow was resolving `python:3.12-slim` to Debian trixie, where `libgl1-mesa-glx` has no package candidate. The GPU Dockerfile also installed from `pyproject.toml` without copying `README.md`, which breaks Hatchling metadata validation.

## Test Coverage
All new behavior is covered by Dockerfile contract tests.

## Validation
- `docker run --rm python:3.12-slim ... apt-cache policy ...` confirmed `libgl1-mesa-glx` is unavailable and `libgl1` is available.
- Focused Docker build using the corrected CPU apt layer and metadata copy completed through `uv pip install -e ".[demo,dev]"`.
- Metadata-only Hatchling editable install check passed with `pyproject.toml`, `README.md`, and package stub present.
- `uv run pytest --no-cov tests/contract/test_dockerfiles.py -q` passed: `2 passed`.
- `uv run ruff check .` passed.
- `uv run ruff format --check .` passed.
- `uv run mypy src/` passed.
- `MUJOCO_GL=osmesa uv run pytest -q` passed: `572 passed, 3 skipped`, coverage `91.88%`.

## Test Plan
- [x] Docker package availability checked against `python:3.12-slim`.
- [x] Focused Docker build validated past the original failing layers.
- [x] Contract tests, lint, format check, type check, and full pytest passed locally.