### PR TITLE
fix(ci): add Docker unitree build tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM python:3.12-slim
 # System dependencies for MuJoCo headless rendering (OSMesa)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
         libosmesa6-dev \
         libgl1 \
         git \

--- a/tests/contract/test_dockerfiles.py
+++ b/tests/contract/test_dockerfiles.py
@@ -25,3 +25,12 @@ def test_dockerfiles_copy_readme_before_editable_install() -> None:
         install_index = dockerfile.index('RUN uv pip install -e "')
 
         assert readme_index < install_index
+
+
+def test_cpu_dockerfile_has_unitree_build_toolchain() -> None:
+    dockerfile = _dockerfile("Dockerfile")
+    unitree_install_index = dockerfile.index('RUN uv pip install "unitree-sdk2py')
+
+    for package in ("build-essential", "cmake"):
+        package_index = dockerfile.index(package)
+        assert package_index < unitree_install_index


### PR DESCRIPTION
## Summary
- Install `build-essential` and `cmake` in the CPU CI Docker image before the `unitree-sdk2py` install layer.
- Add a Dockerfile contract test that keeps those native build tools before the Unitree SDK layer.

## Root Cause
After PR #223 fixed the original Docker image failures and was merged, the `Build CI Docker Image` workflow on `main` progressed further and failed in the CPU image at the Unitree SDK layer. The job log shows `unitree-sdk2py` building CycloneDDS and failing with `error: [Errno 2] No such file or directory: 'cmake'`.

## Validation
- `gh run view 26202892123 --job 77096396168 --log` confirmed the CPU Docker build failure is missing `cmake` during the Unitree SDK build.
- `uv run pytest --no-cov tests/contract/test_dockerfiles.py -q` passed: `3 passed`.
- `uv run ruff check .` passed.
- `uv run ruff format --check .` passed.
- `uv run mypy src/` passed.
- `git diff --check` passed.

## Notes
The GPU image from the merged main run passed. This PR targets the remaining CPU Docker image failure.

## Test Plan
- [x] Focused Dockerfile contract tests passed.
- [x] Lint, format check, type check, and whitespace check passed locally.