### PR TITLE
fix(pages): preserve checkpoint nesting so deployed 3D scenes resolve

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -91,32 +91,41 @@ jobs:
       - name: Build demo reports
         run: |
           # --- Demo 1: Simple Grasp (with Meshcat 3D) ---
+          # The report's iframe src values are relative to the harness output
+          # root (e.g. mujoco_grasp/trial_001/<cp>/meshcat_scene.html), so the
+          # deployed checkpoint assets must preserve that nesting under
+          # _site/grasp/ or the 3D scenes 404.
           mkdir -p _site/grasp
           cp harness_output/report.html _site/grasp/index.html
           for cp_dir in harness_output/mujoco_grasp/trial_001/*/; do
             cp_name=$(basename "$cp_dir")
-            mkdir -p "_site/grasp/${cp_name}"
-            cp "${cp_dir}"*_rgb.png "_site/grasp/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"*_depth_viz.png "_site/grasp/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"meshcat_scene.html "_site/grasp/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"metadata.json "_site/grasp/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"state.json "_site/grasp/${cp_name}/" 2>/dev/null || true
+            dest="_site/grasp/mujoco_grasp/trial_001/${cp_name}"
+            mkdir -p "$dest"
+            cp "${cp_dir}"*_rgb.png "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"*_depth_viz.png "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"meshcat_scene.html "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"metadata.json "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"state.json "$dest/" 2>/dev/null || true
           done
           cp harness_output/mujoco_grasp/trial_001/autonomous_report.json _site/grasp/ 2>/dev/null || true
           cp harness_output/mujoco_grasp/trial_001/alarms.json _site/grasp/ 2>/dev/null || true
           cp harness_output/mujoco_grasp/trial_001/phase_manifest.json _site/grasp/ 2>/dev/null || true
 
           # --- Demo 2: G1 WBC Reach ---
+          # As with the grasp demo, the report references meshcat scenes by
+          # their output-relative path (g1_wbc_reach/trial_001/<cp>/...), so the
+          # deployed assets keep that nesting under _site/g1-reach/.
           mkdir -p _site/g1-reach
           cp harness_output/g1_wbc_reach_report.html _site/g1-reach/index.html
           for cp_dir in harness_output/g1_wbc_reach/trial_001/*/; do
             cp_name=$(basename "$cp_dir")
-            mkdir -p "_site/g1-reach/${cp_name}"
-            cp "${cp_dir}"*_rgb.png "_site/g1-reach/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"*_depth_viz.png "_site/g1-reach/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"meshcat_scene.html "_site/g1-reach/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"metadata.json "_site/g1-reach/${cp_name}/" 2>/dev/null || true
-            cp "${cp_dir}"state.json "_site/g1-reach/${cp_name}/" 2>/dev/null || true
+            dest="_site/g1-reach/g1_wbc_reach/trial_001/${cp_name}"
+            mkdir -p "$dest"
+            cp "${cp_dir}"*_rgb.png "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"*_depth_viz.png "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"meshcat_scene.html "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"metadata.json "$dest/" 2>/dev/null || true
+            cp "${cp_dir}"state.json "$dest/" 2>/dev/null || true
           done
 
           # --- Demo 3: LeRobot G1 Locomotion ---


### PR DESCRIPTION
## Problem

On the deployed site (e.g. `https://miaodx.com/roboharness/grasp/index.html`), every **Interactive 3D Scene** panel showed a `404 / File not found`.

## Root cause

`reporting.py` emits each meshcat iframe `src` as a path **relative to the harness output root**, e.g. `mujoco_grasp/trial_001/<cp>/meshcat_scene.html`. This is correct for local viewing (the report sits at the output root) and is locked in by a regression test.

The GitHub Pages deploy (`.github/workflows/pages.yml`), however, **flattened** the checkpoints into `_site/grasp/<cp>/`. So the deployed report at `grasp/index.html` resolved its iframe to `grasp/mujoco_grasp/trial_001/<cp>/meshcat_scene.html` — which didn't exist → 404. Camera images survived only because they're base64-embedded; the meshcat HTML is the one asset referenced by URL.

This is FINDING-001 (`docs/designs/mujoco-grasp-report-design-audit-20260415.md`) resurfacing on the deployed artifact: the earlier fix corrected the local layout but the deploy layout still diverged.

## Fix

Deploy the grasp and g1-reach checkpoint assets under the nested path the report actually links to (`_site/grasp/mujoco_grasp/trial_001/<cp>/` and `_site/g1-reach/g1_wbc_reach/trial_001/<cp>/`) instead of flattening them. No source/report changes, so the existing regression test stays valid and local viewing is unaffected.

## Test plan

- [ ] `pages.yml` re-run on `main` deploys with the nested layout
- [ ] `https://miaodx.com/roboharness/grasp/index.html` loads the 3D scenes (no 404)
- [ ] g1-reach report scenes load


---
_Generated by [Claude Code](https://claude.ai/code/session_01UTMNfmaXGFrNHjCYMSHWmb)_