### PR TITLE
Fix suite proof pack case path resolution

### DIFF
--- a/src/roboharness/evidence/proof_pack.py
+++ b/src/roboharness/evidence/proof_pack.py
@@ -905,7 +905,14 @@ def _suite_case_dir(suite_dir: Path, result: dict[str, Any]) -> Path:
     output_dir = result.get("output_dir")
     if isinstance(output_dir, str) and output_dir:
         path = Path(output_dir)
-        return path if path.is_absolute() else suite_dir / path
+        if path.is_absolute():
+            return path
+        if path.exists():
+            return path
+        suite_relative = suite_dir / path
+        if suite_relative.exists():
+            return suite_relative
+        return path
     artifact_dir_name = result.get("artifact_dir_name")
     if isinstance(artifact_dir_name, str) and artifact_dir_name:
         return suite_dir / artifact_dir_name

--- a/tests/unit/evidence/test_proof_pack.py
+++ b/tests/unit/evidence/test_proof_pack.py
@@ -234,6 +234,41 @@ def test_build_suite_proof_pack_and_visual_review_queue_from_case_artifacts(
     assert queue_payload["total_items"] == 1
 
 
+def test_suite_proof_pack_accepts_repo_relative_case_output_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    suite_root = repo_root / "tmp" / "visual_harness" / "suite"
+    case_dir = suite_root / "X36_Y28_Z13"
+    _write_groot_case(case_dir)
+    suite_report_path = suite_root / "suite_report_representative.json"
+    _write_json(
+        suite_report_path,
+        {
+            "suite_name": "representative",
+            "output_root": suite_root.as_posix(),
+            "results": [
+                {
+                    "case_id": "X36_Y28_Z13",
+                    "output_dir": "tmp/visual_harness/suite/X36_Y28_Z13",
+                    "status": "pass",
+                }
+            ],
+        },
+    )
+    monkeypatch.chdir(repo_root)
+
+    suite_proof_pack = build_suite_proof_pack(suite_report_path)
+    queue = build_visual_review_queue(suite_proof_pack)
+
+    assert suite_proof_pack.reviewable_count == 1
+    assert suite_proof_pack.skipped_count == 0
+    assert suite_proof_pack.cases[0].case_dir == "X36_Y28_Z13"
+    assert suite_proof_pack.cases[0].proof_pack_path == "X36_Y28_Z13/proof_pack.json"
+    assert len(queue.items) == 1
+
+
 def test_suite_proof_pack_skips_execution_errors(tmp_path: Path) -> None:
     suite_report_path = tmp_path / "suite_report_representative.json"
     _write_json(


### PR DESCRIPTION
## Summary
- resolve repo-relative suite result output_dir values before falling back to suite-relative paths
- add regression coverage for GR00T-style suite reports

## Verification
- uv run ruff check src/roboharness/evidence/proof_pack.py tests/unit/evidence/test_proof_pack.py
- uv run ruff format --check src/roboharness/evidence/proof_pack.py tests/unit/evidence/test_proof_pack.py
- uv run mypy src/roboharness/evidence/proof_pack.py
- uv run pytest -q tests/unit/evidence/test_proof_pack.py tests/unit/approval/test_visual_review.py --cov-fail-under=0
- uv run ruff check . && uv run ruff format --check . && uv run mypy src/